### PR TITLE
Feature/region default blocks

### DIFF
--- a/resources/assets/js/classes/Definition.js
+++ b/resources/assets/js/classes/Definition.js
@@ -97,15 +97,15 @@ export default class Definition {
 		return null;
 	}
 
-	static fillBlockFields(block) {
+	static fillBlockFields(block, definition = null) {
 		const type = Definition.getType({
 			name   : block.definition_name,
 			version: block.definition_version
 		});
 
-		if(type && Definition.get(type)) {
+		if(type && (Definition.get(type) || definition)) {
 
-			Definition.get(type).fields.forEach(field => {
+			(Definition.get(type) || definition).fields.forEach(field => {
 
 				if(block.fields[field.name] === void 0) {
 					let value;

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -1,0 +1,167 @@
+<template>
+<el-dialog title="Create Page" v-model="visible" :modal-append-to-body="false">
+	<el-form :model="createForm">
+		<el-form-item label="Page title">
+			<el-input name="title" v-model="createForm.title" auto-complete="off"></el-input>
+		</el-form-item>
+		<el-select
+			name="layout_name"
+			v-model="createForm.layout_name"
+			@change="getLayout"
+		>
+			<el-option
+					v-for="item in layouts"
+					:key="item.name"
+					:label="item.label"
+					:value="item.name">
+			</el-option>
+		</el-select>
+		<el-form-item label="Layout Version">
+			<el-input name="layout_version" v-model="createForm.layout_version" auto-complete="off"></el-input>
+		</el-form-item>
+		<el-form-item label="slug">
+			<el-input name="slug" v-model="createForm.route.slug" auto-complete="off"></el-input>
+		</el-form-item>
+	</el-form>
+	<span slot="footer" class="dialog-footer">
+	<el-button @click="visible = false">Cancel</el-button>
+	<el-button type="primary" @click="addChild">Confirm</el-button>
+</span>
+</el-dialog>
+</template>
+
+<script>
+import { mapState, mapActions } from 'vuex';
+import { Definition } from 'classes/helpers';
+
+export default {
+
+	name: 'create-page-modal',
+
+	data() {
+		return {
+			layouts: [
+				{
+					label: 'Kent homepage',
+					name: 'kent-homepage'
+				},
+				{
+					label: 'Astro 2017',
+					name: 'astro17'
+				}
+			],
+			createForm: {
+				title: 'Unnamed Page',
+				layout_name: 'kent-homepage',
+				layout_version: 1,
+				route: {
+					slug: 'testing',
+					parent_id: 1
+				},
+				blocks: {},
+				options: {}
+			}
+		};
+	},
+
+	computed: {
+		...mapState('site', {
+			pages: state => state.pages,
+			pageModal: state => state.pageModal
+		}),
+
+		visible: {
+			get() {
+				this.createForm.route.parent_id = this.pageModal.parentId;
+				return this.pageModal.visible;
+			},
+			set(show) {
+				if(!show) {
+					this.hidePageModal();
+				}
+			}
+		},
+	},
+
+	created() {
+		this.fetchSite();
+		this.getLayout(this.createForm.layout_name);
+	},
+
+	methods: {
+		...mapActions({
+			fetchSite: 'site/fetchSite',
+			createPage: 'site/createPage',
+			hidePageModal: 'site/hidePageModal'
+		}),
+
+		addChild() {
+			this.createPage(this.createForm);
+			this.visible = false;
+		},
+
+		saveEdit() {
+			// TODO: when endpoint is ready, update this
+			// this.updatePage({
+			// 	title: this.currentPage.title,
+			// 	id: this.currentPage.id,
+			// 	page_id: this.currentPage.page_id,
+			// 	layout_name: this.layout_name,
+			// 	layout_version: this.layout_version,
+			// 	route: {
+			// 		slug: this.currentPage.slug,
+			// 		parent_id: this.currentPage.parent_id
+			// 	}
+			// });
+		},
+
+		getLayout(layoutName) {
+			this.createForm.blocks = {};
+			this.$api
+				.get(`layout/${layoutName}/definition?include=region_definitions.block_definitions`)
+				.then(({ data: json }) => {
+					// go through our region definitions
+					json.data.region_definitions.forEach((region) => {
+						// if "default" blocks have been set and
+						// we have some block definitions, try adding them
+						if(region.default && region.block_definitions) {
+
+							region.default.forEach((blockName) => {
+								// see if this particular block definition exists
+								const blockDefinition = region.block_definitions.find(
+									(def) => def.name === blockName
+								);
+
+								if(blockDefinition) {
+									if(!this.createForm.blocks[region.name]) {
+										this.createForm.blocks[region.name] = [];
+									}
+
+									// add our empty block
+									const length = this.createForm.blocks[region.name].push({
+										definition_name: blockDefinition.name,
+										definition_version: blockDefinition.version,
+										fields: {}
+									});
+
+									// fill in the block's fields with their default values
+									Definition.fillBlockFields(
+										this.createForm.blocks[region.name][length - 1],
+										blockDefinition
+									)
+
+									// add them to our create form (not directly
+									// modifying the property so it can react to changes)
+									this.createForm = {
+										...this.createForm,
+										blocks: this.createForm.blocks
+									};
+								}
+							});
+						}
+					});
+				});
+		}
+	}
+};
+</script>

--- a/resources/assets/js/components/ModalContainer.vue
+++ b/resources/assets/js/components/ModalContainer.vue
@@ -4,6 +4,7 @@
 	<publish-modal />
 	<media-picker />
 	<media-overlay size="small" />
+	<create-page-modal />
 </div>
 </template>
 
@@ -12,6 +13,7 @@ import BlockPicker from 'components/BlockPicker';
 import PublishModal from 'components/PublishModal';
 import MediaPicker from 'components/MediaPicker';
 import MediaOverlay from 'components/media/MediaOverlay';
+import CreatePageModal from 'components/CreatePageModal';
 
 export default {
 
@@ -21,7 +23,8 @@ export default {
 		BlockPicker,
 		PublishModal,
 		MediaPicker,
-		MediaOverlay
+		MediaOverlay,
+		CreatePageModal
 	}
 
 };

--- a/resources/assets/js/components/PageList.vue
+++ b/resources/assets/js/components/PageList.vue
@@ -7,43 +7,14 @@
 			:key="page.id"
 			:page="page"
 			:flatten="true"
-			:open-modal="openModal"
+			:open-modal="showPageModal"
 			path="0"
 			:depth="0"
 		/>
 	</div>
 
-	<!-- TODO: move out into a container fo all modal windows -->
-	<div id="create-form">
-		<el-dialog title="Create Page" v-if="createFormVisible" :visible.sync="createFormVisible" :modal-append-to-body=false >
-			<el-form :model="createForm">
-				<el-form-item label="Page title">
-					<el-input name="title" v-model="createForm.title" auto-complete="off"></el-input>
-				</el-form-item>
-				<el-select name="layout_name" v-model="createForm.layout_name" placeholder="Select">
-					<el-option
-							v-for="item in layouts"
-							:key="item"
-							:label="item"
-							:value="item">
-					</el-option>
-				</el-select>
-				<el-form-item label="Layout Version">
-					<el-input name="layout_version" v-model="createForm.layout_version" auto-complete="off"></el-input>
-				</el-form-item>
-				<el-form-item label="slug">
-					<el-input name="slug" v-model="createForm.route.slug" auto-complete="off"></el-input>
-				</el-form-item>
-			</el-form>
-			<span slot="footer" class="dialog-footer">
-			<el-button @click="createFormVisible = false">Cancel</el-button>
-			<el-button type="primary" @click="addChild">Confirm</el-button>
-		</span>
-		</el-dialog>
-	</div>
-
 	<div class="b-bottom-bar">
-		<el-button class="u-mla" @click="() => { this.openModal(this.$children[2]) }">+ Add Page</el-button>
+		<el-button class="u-mla" @click="() => { this.showPageModal(pages[0]) }">+ Add Page</el-button>
 	</div>
 </div>
 </template>
@@ -69,20 +40,7 @@ export default {
 
 	data() {
 		return {
-			loading: true,
-			createFormVisible: false,
-			settingsFormVisible: false,
-			layouts: [],
-			createForm: {
-				title: 'Unnamed Page',
-				layout_name: 'kent-homepage',
-				layout_version: 1,
-				route: {
-					slug: 'testing',
-					parent_id: 1
-				},
-				options: {}
-			}
+			loading: true
 		};
 	},
 
@@ -94,47 +52,8 @@ export default {
 
 	methods: {
 		...mapActions({
-			fetchSite: 'site/fetchSite',
-			createPage: 'site/createPage'
-		}),
-
-		openModal(pageItem) {
-			this.currentPage = pageItem;
-			this.createFormVisible = true;
-			this.createForm.route.parent_id = pageItem.page.id;
-		},
-
-		addChild() {
-			this.createPage(this.createForm);
-			this.createFormVisible = false;
-			this.currentPage.openPage();
-			this.currentPage = null;
-		},
-
-		openRename() {
-			this.renameFormVisible = true;
-		},
-
-		saveEdit() {
-			this.renameFormVisible = false;
-			// TODO: when endpoint is ready, update this
-			// this.updatePage({
-			// 	title: this.currentPage.title,
-			// 	id: this.currentPage.id,
-			// 	page_id: this.currentPage.page_id,
-			// 	layout_name: this.layout_name,
-			// 	layout_version: this.layout_version,
-			// 	route: {
-			// 		slug: this.currentPage.slug,
-			// 		parent_id: this.currentPage.parent_id
-			// 	}
-			// });
-		}
-	},
-
-	created() {
-		this.fetchSite();
-		this.$bus.$on('rename-page', (id) => this.edit = id);
+			showPageModal: 'site/showPageModal'
+		})
 	}
 };
 </script>

--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -205,7 +205,7 @@ export default {
 
 		handleCommand(command) {
 			if(this[command]) {
-				this[command](this);
+				this[command](this.page);
 			}
 		}
 

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -8,7 +8,11 @@ const state = {
 	pages: [],
 	site: 1,
 	layouts: [],
-	maxDepth: 3
+	maxDepth: 3,
+	pageModal: {
+		visible: false,
+		parentId: null
+	}
 };
 
 const mutations = {
@@ -36,8 +40,15 @@ const mutations = {
 
 	updatePageDepth(state, { page, depth }) {
 		page.depth = depth;
-	}
+	},
 
+	setPageModalVisibility(state, visible) {
+		state.pageModal.visible = visible;
+	},
+
+	setPageModalParent(state, pageId) {
+		state.pageModal.parentId = pageId;
+	}
 };
 
 const actions = {
@@ -123,6 +134,15 @@ const actions = {
 				`
 			});
 		}
+	},
+
+	showPageModal({ commit }, { id }) {
+		commit('setPageModalParent', id);
+		commit('setPageModalVisibility', true);
+	},
+
+	hidePageModal({ commit }) {
+		commit('setPageModalVisibility', false);
 	}
 
 };


### PR DESCRIPTION
This allows us to have a "default" array of blocks in our region definitions and they will be added on page creation, with their default field values. e.g.
```
	"default": [
		"feature-panel--cta",
		"lead",
		"content",
		"feature-panel--video"
	]
```