### PR TITLE
Tell Laravel what its root URL is to avoid wrongly redirecting due to…

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -30,6 +30,11 @@ class RouteServiceProvider extends ServiceProvider
 	{
 		parent::boot();
 
+        /** @var \Illuminate\Routing\UrlGenerator $url */
+        $url = $this->app['url'];
+        // Force the application URL
+        $url->forceRootUrl(config('app.url'));
+
 	    Route::bind('page', function($value){
 	        return Page::where('id', '=', $value)->firstOrFail();
 	    });


### PR DESCRIPTION
… proxies or something...

Added some code to the route provider to use the url given in .env / config/app.php as the route url for all
generated urls.

Prior to this, on webtools-test laravel was wrongly identifying the hostname when generating routes.