### PR TITLE
Feature/autosave when navigating

### DIFF
--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -188,7 +188,7 @@ export default {
 		edit() {
 		    const page_id = this.page.id;
 			if(Number.parseInt(this.$route.params.page_id) !== page_id) {
-				/* autosave and unsaved changes before we switch to the new page */
+				/* autosave any unsaved changes before we switch to the new page */
 				const unsavedChangesExist = this.unsavedChangesExist();
 				if (unsavedChangesExist) {
 					this.savePage();

--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -182,7 +182,7 @@ export default {
 		},
 
 		savePage() {
-			this.handleSavePage({id: this.$route.params.page_id, message: this.$message});
+			this.handleSavePage({message: this.$message});
 		},
 
 		edit() {

--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -129,7 +129,8 @@ export default {
 		...mapActions({
 			movePage: 'site/movePage',
 			deletePage: 'site/deletePage',
-			updatePage: 'site/updatePage'
+			updatePage: 'site/updatePage',
+		    handleSavePage: 'handleSavePage'
 		}),
 
 		handleDragEnd() {
@@ -180,18 +181,20 @@ export default {
 			}
 		},
 
+		savePage() {
+			this.handleSavePage({id: this.$route.params.page_id, message: this.$message});
+		},
+
 		edit() {
 		    const page_id = this.page.id;
 			if(Number.parseInt(this.$route.params.page_id) !== page_id) {
-				this.setLoaded(false);
-				this.$router.push(`/site/${this.site}/page/${page_id}`);
-				console.log('switching pages in editor');
+				/* autosave and unsaved changes before we switch to the new page */
 				const unsavedChangesExist = this.unsavedChangesExist();
 				if (unsavedChangesExist) {
-					alert('unsaved changes exist - save prompt goes here');
-				} else {
-					console.log('unsaved changes do not exist');
+					this.savePage();
 				}
+				this.setLoaded(false);
+				this.$router.push(`/site/${this.site}/page/${page_id}`);
 				this.$store.commit('changePage', this.page.path);
 			}
 			else {

--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -67,7 +67,7 @@
 </template>
 
 <script>
-import { mapState, mapActions, mapMutations } from 'vuex';
+import { mapState, mapActions, mapMutations, mapGetters } from 'vuex';
 import Draggable from 'vuedraggable';
 import Icon from 'components/Icon';
 
@@ -92,6 +92,10 @@ export default {
 		...mapState('site', {
 			site: state => state.site
 		}),
+
+		...mapGetters([
+			'unsavedChangesExist'
+		]),
 
 		root() {
 			return this.depth === 0;
@@ -181,6 +185,13 @@ export default {
 			if(Number.parseInt(this.$route.params.page_id) !== page_id) {
 				this.setLoaded(false);
 				this.$router.push(`/site/${this.site}/page/${page_id}`);
+				console.log('switching pages in editor');
+				const unsavedChangesExist = this.unsavedChangesExist();
+				if (unsavedChangesExist) {
+					alert('unsaved changes exist - save prompt goes here');
+				} else {
+					console.log('unsaved changes do not exist');
+				}
 				this.$store.commit('changePage', this.page.path);
 			}
 			else {

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import { mapState, mapGetters } from 'vuex';
+import { mapState, mapGetters, mapActions } from 'vuex';
 import Icon from 'components/Icon';
 import { undoStackInstance } from 'plugins/undo-redo';
 import { onKeyDown, onKeyUp } from 'plugins/key-commands';
@@ -82,6 +82,14 @@ export default {
 
 	methods: {
 
+		...mapActions([
+			'handleSavePage'
+		]),
+
+		savePage() {
+			this.handleSavePage({message: this.$message});
+		},
+
 		handleCommand(command) {
 			if(command === 'sign-out') {
 				window.location = '/auth/logout';
@@ -89,14 +97,11 @@ export default {
 		},
 
 		backToSites() {
-			console.log('switching back to site');
+			/* autosave any unsaved changes before we switch to the new page */
 			const unsavedChangesExist = this.unsavedChangesExist();
 			if (unsavedChangesExist) {
-				alert('unsaved changes exist - save prompt goes here');
-			} else {
-				console.log('unsaved changes do not exist');
+				this.savePage();
 			}
-
 			this.$store.commit('changePage', '');
 			this.$store.commit('setPage', {});
 			this.$store.commit('setLoaded', false);

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import Icon from 'components/Icon';
 import { undoStackInstance } from 'plugins/undo-redo';
 import { onKeyDown, onKeyUp } from 'plugins/key-commands';
@@ -67,6 +67,10 @@ export default {
 			pageName: state => state.page.pageName,
 		}),
 
+		...mapGetters([
+			'unsavedChangesExist'
+		]),
+
 		showBack() {
 			return ['site', 'page'].indexOf(this.$route.name) !== -1;
 		},
@@ -85,6 +89,14 @@ export default {
 		},
 
 		backToSites() {
+			console.log('switching back to site');
+			const unsavedChangesExist = this.unsavedChangesExist();
+			if (unsavedChangesExist) {
+				alert('unsaved changes exist - save prompt goes here');
+			} else {
+				console.log('unsaved changes do not exist');
+			}
+
 			this.$store.commit('changePage', '');
 			this.$store.commit('setPage', {});
 			this.$store.commit('setLoaded', false);

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -86,22 +86,23 @@ export default {
 			'handleSavePage'
 		]),
 
-		savePage() {
-			this.handleSavePage({message: this.$message});
+		/* if user has unsaved changes then save the changes */
+		autoSave() {
+			const unsavedChangesExist = this.unsavedChangesExist();
+			if (unsavedChangesExist) {
+				this.handleSavePage({message: this.$message});
+			}
 		},
 
 		handleCommand(command) {
 			if(command === 'sign-out') {
+				this.autoSave();
 				window.location = '/auth/logout';
 			}
 		},
 
 		backToSites() {
-			/* autosave any unsaved changes before we switch to the new page */
-			const unsavedChangesExist = this.unsavedChangesExist();
-			if (unsavedChangesExist) {
-				this.savePage();
-			}
+			this.autoSave();
 			this.$store.commit('changePage', '');
 			this.$store.commit('setPage', {});
 			this.$store.commit('setLoaded', false);

--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -111,7 +111,7 @@ export default {
 		},
 
 		savePage() {
-			this.handleSavePage(this.$route.params.page_id);
+			this.handleSavePage({id: this.$route.params.page_id, message: this.$message});
 		},
 
 		// TODO - add preview the page functionality

--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -23,7 +23,7 @@
 
 	<el-button class="toolbar__button-save" type="success" @click="savePage">Save</el-button>
 
-	<a class="el-button el-button--info toolbar__button-preview" type="info" :href="draftLink" target="_blank">Preview <icon name="newwindow" aria-hidden="true" width="14" height="14" class="ico" /></a>
+	<el-button class="toolbar__button-preview" type="info" @click="previewPage">Preview <icon name="newwindow" aria-hidden="true" width="14" height="14" class="ico" /></el-button>
 
 	<el-button class="toolbar__button-publish" type="danger" @click="showPublishModal">Publish ...</el-button>
 
@@ -114,13 +114,14 @@ export default {
 			this.handleSavePage({id: this.$route.params.page_id, message: this.$message});
 		},
 
-		// TODO - add preview the page functionality
+		/* autosave the page and open a preview window */
 		previewPage() {
-			this.$message({
-				message: 'TODO: previewing page...',
-				type: 'success',
-				duration: 2000
-			});
+			/* handleSavePage returns a promise so we here we wait for it to complete before
+			opening the preview window */
+			this.handleSavePage({id: this.$route.params.page_id, message: this.$message})
+				.then(() => {
+					window.open(this.draftLink,'_blank');
+				});
 		},
 
 		undo() {

--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -34,7 +34,7 @@
 
 
 <script>
-import { mapState, mapMutations } from 'vuex';
+import { mapState, mapMutations, mapActions } from 'vuex';
 
 import Icon from 'components/Icon';
 import { undoStackInstance } from 'plugins/undo-redo';
@@ -99,7 +99,11 @@ export default {
 	methods: {
 		...mapMutations([
 			'changeView',
-			'showPublishModal'
+			'showPublishModal',
+		]),
+
+		...mapActions([
+			'handleSavePage'
 		]),
 
 		updateCurrentSavedState() {
@@ -107,20 +111,7 @@ export default {
 		},
 
 		savePage() {
-			this.$api
-				.put(`pages/${this.$route.params.page_id}/content`, {
-                    blocks: this.page.blocks
-                })
-				.then(() => {
-					this.$message({
-						message: 'Page saved',
-						type: 'success',
-						duration: 2000
-					});
-					// update saved state here
-					this.updateCurrentSavedState();
-				})
-				.catch(() => {});
+			this.handleSavePage(this.$route.params.page_id);
 		},
 
 		// TODO - add preview the page functionality

--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -101,6 +101,11 @@ export default {
 			'changeView',
 			'showPublishModal'
 		]),
+
+		updateCurrentSavedState() {
+			this.$store.commit('updateCurrentSavedState');
+		},
+
 		savePage() {
 			this.$api
 				.put(`pages/${this.$route.params.page_id}/content`, {
@@ -112,6 +117,8 @@ export default {
 						type: 'success',
 						duration: 2000
 					});
+					// update saved state here
+					this.updateCurrentSavedState();
 				})
 				.catch(() => {});
 		},

--- a/resources/assets/js/store/index.js
+++ b/resources/assets/js/store/index.js
@@ -37,6 +37,9 @@ let store = new Vuex.Store({
 		publishModal: {
 			visible: false
 		},
+		unsavedChangesModal: {
+			visible: false
+		},
 		menu: {
 			active: 'pages'
 		}
@@ -100,6 +103,14 @@ let store = new Vuex.Store({
 
 		hidePublishModal(state) {
 			state.publishModal.visible = false;
+		},
+
+		showUnsavedChangesModal(state) {
+			state.unsavedChangesModal.visible = true;
+		},
+
+		hideUnsavedChangesModal(state) {
+			state.unsavedChangesModal.visible = false;
 		},
 
 		updateMenuActive(state, id) {

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -204,6 +204,24 @@ const actions = {
 
 			});
 	},
+
+	handleSavePage({ state }, id) {
+			const blocks = state.pageData.blocks;
+			api
+				.put(`pages/${id}/content`, {
+                    blocks: blocks
+                })
+				.then(() => {
+					this.$message({
+						message: 'Page saved',
+						type: 'success',
+						duration: 2000
+					});
+					// update saved state here
+					this.updateCurrentSavedState();
+				})
+				.catch(() => {});
+		},
 };
 
 const getters = {

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -23,7 +23,8 @@ const state = {
 	pageName: '',
 	scale: .4,
 	loaded: false,
-	dragging: false
+	dragging: false,
+	currentSavedState: ''
 };
 
 const mutations = {
@@ -149,6 +150,10 @@ const mutations = {
 
 		// TODO: use state for this
 		Vue.nextTick(() => eventBus.$emit('block:updateOverlay', index));
+	},
+
+	updateCurrentSavedState(state) {
+		state.currentSavedState = JSON.stringify(state.pageData.blocks);
 	}
 };
 
@@ -198,7 +203,7 @@ const actions = {
 					});
 
 			});
-	}
+	},
 };
 
 const getters = {
@@ -233,6 +238,10 @@ const getters = {
 	scaleUp: (state) => () => {
 		// return scale with three digits after decimal point
 		return state.scale !== 0 ? Math.round(1 / state.scale * 1000) / 1000 : 1;
+	},
+
+	unsavedChangesExist: (state) => () => {
+		return state.currentSavedState != JSON.stringify(state.pageData.blocks);
 	}
 };
 

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -208,13 +208,16 @@ const actions = {
 	/**
 	 * Saves a page
 	 * @param {Object} state - the context of the action - added by VueX
+	 * @param {Object} commit - added by VueX
 	 * @param {Object} payload - parameter object
 	 * @param {callback} payload.message - function to display a message
+	 * @return {promise} - api - to allow other methods to wait for the save 
+	 * to complete
 	 */
-	handleSavePage({ state }, payload) {
+	handleSavePage({ state, commit }, payload) {
 			const blocks = state.pageData.blocks;
 			const id = state.pageData.id;
-			api
+			return api
 				.put(`pages/${id}/content`, {
                     blocks: blocks
                 })
@@ -224,10 +227,10 @@ const actions = {
 							type: 'success',
 							duration: 2000
 						});
-					this.updateCurrentSavedState();
+					commit('updateCurrentSavedState');
 				})
 				.catch(() => {});
-		},
+	},
 };
 
 const getters = {

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -205,19 +205,25 @@ const actions = {
 			});
 	},
 
-	handleSavePage({ state }, id) {
+	/**
+	 * Saves a page
+	 * @param {Object} state - the context of the action - added by VueX
+	 * @param {Object} payload - parameter object
+	 * @param {string} payload.id - the id of the page
+	 * @param {callback} payload.message - function to display a message
+	 */
+	handleSavePage({ state }, payload) {
 			const blocks = state.pageData.blocks;
 			api
-				.put(`pages/${id}/content`, {
+				.put(`pages/${payload.id}/content`, {
                     blocks: blocks
                 })
 				.then(() => {
-					this.$message({
-						message: 'Page saved',
-						type: 'success',
-						duration: 2000
-					});
-					// update saved state here
+					payload.message({
+							message: 'Page saved',
+							type: 'success',
+							duration: 2000
+						});
 					this.updateCurrentSavedState();
 				})
 				.catch(() => {});

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -209,13 +209,13 @@ const actions = {
 	 * Saves a page
 	 * @param {Object} state - the context of the action - added by VueX
 	 * @param {Object} payload - parameter object
-	 * @param {string} payload.id - the id of the page
 	 * @param {callback} payload.message - function to display a message
 	 */
 	handleSavePage({ state }, payload) {
 			const blocks = state.pageData.blocks;
+			const id = state.pageData.id;
 			api
-				.put(`pages/${payload.id}/content`, {
+				.put(`pages/${id}/content`, {
                     blocks: blocks
                 })
 				.then(() => {

--- a/resources/assets/js/views/Editor.vue
+++ b/resources/assets/js/views/Editor.vue
@@ -65,6 +65,10 @@ export default {
 				text: 'Loading preview...',
 				customClass: 'loading-overlay'
 			});
+		},
+
+		updateCurrentSavedState() {
+			this.$store.commit('updateCurrentSavedState');
 		}
 	},
 	computed: {
@@ -95,6 +99,7 @@ export default {
 
 	watch: {
 		pageLoaded(hideLoader) {
+			this.updateCurrentSavedState();
 			if(hideLoader) {
 				this.loader.close();
 			}


### PR DESCRIPTION
Hi, 

Hope this makes sense. This branch covers https://trello.com/c/b5MbvODT/181-autosave-mvp-when-users-navigate-to-another-page-or-another-section-within-astro-the-page-that-they-were-currently-editing-is-au whic was the first point on the checklist on https://trello.com/c/9O4q5j3w/179-autosaving-mvp. This covers saving when navigating around the editor. 

Autosaving happens when 
* user clicks the '< Site list' link
* uses changes the pages they are currently editing
* user clicked the Preview button
* user logs out

The Preview button was something I found a little confusing at first. I ended up making the new handleSavePage method return the promise from the api. That way I could use that and wait until the page had been saved to the api before opening the preview window. 