### PR TITLE
Made preview button relative to editor-root so works if editor is not at domain root.

### DIFF
--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -68,7 +68,6 @@ export default {
 		},
 
 		draftLink() {
-			//return ;
 			return window.astro.base_url + '/draft/' + `${this.$route.params.page_id}`;
 		}
 	},

--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -69,7 +69,7 @@ export default {
 
 		draftLink() {
 			//return ;
-			return '/draft/' + `${this.$route.params.page_id}`;
+			return window.astro.base_url + '/draft/' + `${this.$route.params.page_id}`;
 		}
 	},
 


### PR DESCRIPTION
For now it just accesses window.astro.base_url which is set on the initial editor load (view page source to see).

I'm not 100% sure this can always be relied on but works for now...

