### PR TITLE
Fix/publish button not working

### DIFF
--- a/app/Models/APICommands/PublishPage.php
+++ b/app/Models/APICommands/PublishPage.php
@@ -19,6 +19,23 @@ use Illuminate\Support\Collection;
 class PublishPage implements APICommand
 {
     /**
+     * Determines if this page is root or if not, if a page with its parent url is published
+     * @param int $page_id The id of an unpublished page to test.
+     */
+    public static function parentIsPublished($page_id)
+    {
+        $page = Page::find($page_id);
+        if(!$page){
+            return false;
+        }
+        if(!$page->parent){
+            return true;
+        }else{
+            return $page->parent->publishedVersion();
+        }
+    }
+
+    /**
      * Carry out the command, based on the provided $input.
      * @param array $input The input options as key=>value pairs.
      * @return mixed
@@ -163,7 +180,8 @@ class PublishPage implements APICommand
     public function messages(Collection $data, Authenticatable $user)
     {
         return [
-            'id' => 'The page does not exist.'
+            'id.exists' => 'The page does not exist.',
+            'id.parent_is_published' => 'The parents of this page must be published first.'
         ];
     }
 
@@ -176,8 +194,9 @@ class PublishPage implements APICommand
     {
         return [
           'id' => [
-              'exists:pages,id'
-          ]
+              'exists:pages,id',
+              'parent_is_published:'.$data->get('id')
+          ],
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\APICommands\PublishPage;
 use App\Models\Page;
 use DB;
 use Laravel\Dusk\DuskServiceProvider;
@@ -20,6 +21,8 @@ class AppServiceProvider extends ServiceProvider
 	public function boot()
 	{
 		Schema::defaultStringLength(191); // Fix for the webfarm running older MySQL
+
+        Validator::extend('parent_is_published', function( $attr, $value ) { return PublishPage::parentIsPublished($value); });
 
 		Validator::extend('definition_exists', function ($attribute, $value, $parameters, $validator){
 			$data = $validator->getData();

--- a/resources/assets/js/components/PublishModal.vue
+++ b/resources/assets/js/components/PublishModal.vue
@@ -61,7 +61,7 @@ export default {
 
 		publishPage() {
 			this.$api
-				.post(`page/${this.$route.params.site_id}/publish`, this.page)
+				.post('pages/' + this.$route.params.page_id + '/publish', this.page)
 				.then(() => {
 					this.hidePublishModal();
 					this.$message({


### PR DESCRIPTION
Fixes the publish button to point to the correct URL and moves the check of whether the page's ancestors are published or not to the validation section of the command.