### PR TITLE
Feature/renderer live

### DIFF
--- a/app/Models/LocalAPIClient.php
+++ b/app/Models/LocalAPIClient.php
@@ -19,6 +19,7 @@ use App\Models\APICommands\CreateSite;
 use App\Models\APICommands\AddPage;
 use Auth;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Prototyping
@@ -48,12 +49,12 @@ class LocalAPIClient implements APIClient
         $this->user = $user;
     }
 
-    public function getRouteDefinition($host, $path)
+    public function getRouteDefinition($host, $path, $version = 'published')
     {
-        $json = $this->resolveRoute($host, $path);
-        $data = json_decode($json->content(),true);
+        $json = $this->resolveRoute($host, $path, $version);
+        $data = $json ? json_decode($json->content(),true) : null;
         if(null === $data){
-            throw new APIErrorException('Non json data returned from API for path "' . $path . '"',APIErrorException::ERR_INVALID_JSON);
+            throw new RouteNotFoundException();//APIErrorException('Non json data returned from API for path "' . $path . '"',APIErrorException::ERR_INVALID_JSON);
         }
         try {
  //           $data['data']['canonical'] = $data['data']['active_route']['path'];

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -245,11 +245,12 @@ class Page extends BaumNode
      * @param $path
      * @return $this
      */
-    public static function findByHostAndPath($host, $path)
+    public static function findByHostAndPath($host, $path, $version = Page::STATE_PUBLISHED)
     {
-        return Page::whereHas('site', function($query) use($host) {
+        return Page::version($version)->whereHas('site', function($query) use($host) {
                 $query->where('host', $host);
             })
+//            ->where('version', '=', $version)
             ->join('sites', 'site_id', '=', 'sites.id')
             ->whereRaw("concat(sites.path, pages.path) = ?", [$path])
             ->first();

--- a/app/Models/Traits/ResolvesRoutes.php
+++ b/app/Models/Traits/ResolvesRoutes.php
@@ -20,15 +20,15 @@ trait ResolvesRoutes
      * @param $path
      * @return $this|\Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\JsonResponse|SymfonyResponse
      */
-    public function resolveRoute($host, $path)
+    public function resolveRoute($host, $path, $version = 'published')
     {
         // Attempt to resolve the Route
-        $page = Page::findByHostAndPath($host, $path);
+        $page = Page::findByHostAndPath($host, $path, $version);
 
         if($page){
             return fractal($page, new PageTransformer(true))->parseIncludes(['site'])->respond();
         }
-        return (new SymfonyResponse())->setStatusCode(404);
+        return null;// (new SymfonyResponse())->setStatusCode(404);
 
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,10 +40,30 @@ Route::get('/draft/{page}', function(Request $request, Page $page) {
     // controller
     $astro = new AstroRenderer();
     $site = $page->site;
-    return $astro->renderRoute($page->site->host, $page->site->path . $page->path, $api, $engine, $locator);
+    return $astro->renderRoute($page->site->host, $page->site->path . $page->path, $api, $engine, $locator, Page::STATE_DRAFT);
 })
 ->where('route', '(.*?)/?')
 ->middleware('auth');
+
+Route::get('/published/{host}/{path?}', function(Request $request, $host, $path = '') {
+    // Template, definitions, etc locator
+    $path = '/' . $path;
+
+    $locator = new SingleDefinitionsFolderLocator(
+        Config::get('app.definitions_path') ,
+        'Astro\Renderer\Base\Block',
+        'Astro\Renderer\Base\Layout'
+    );
+    $app_url = Config::get('app.url') . '/draft';
+    $api = new LocalAPIClient();
+    $engine = new TwigEngine(Config::get('app.definitions_path'));
+
+    // controller
+    $astro = new AstroRenderer();
+    return $astro->renderRoute($host, $path, $api, $engine, $locator, Page::STATE_PUBLISHED);
+})
+->where('host', '([^/]+)')
+->where('path', '(.*?)/?');
 
 Route::get('/{catchall?}', function($route = '') {
 	$user = Auth::user();


### PR DESCRIPTION
For now, adds a new route to astro for displaying the published version of a site.

The published version can be accessed at /path/to/editor/published/<domain-name>/<path-to-page>

Currently, "example.com" is used as the site domain name, so to access to root (published) page on test would be:

https://webtools-test.kent.ac.uk/site-editor/published/example.com/

and the undergraduate page would be:

https://webtools-test.kent.ac.uk/site-editor/published/example.com/undergraduate

(obviously neither of these links will work until this request is accepted and deployed!

Most of the changes relate to modifying functions to retrieve pages to allow specifying the state to look for (draft or published).