### PR TITLE
Feature/prompt to save not autosave

### DIFF
--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -73,6 +73,7 @@
 import { mapState, mapActions, mapMutations, mapGetters } from 'vuex';
 import Draggable from 'vuedraggable';
 import Icon from 'components/Icon';
+import promptToSave from '../mixins/promptToSave';
 
 export default {
 	name: 'page-list-item',
@@ -83,6 +84,8 @@ export default {
 		Icon,
 		Draggable
 	},
+
+	mixins:[ promptToSave ],
 
 	data() {
 		return {
@@ -188,21 +191,15 @@ export default {
 			}
 		},
 
-		savePage() {
-			this.handleSavePage({message: this.$message});
-		},
-
 		edit() {
 		    const page_id = this.page.id;
 			if(Number.parseInt(this.$route.params.page_id) !== page_id) {
 				/* autosave any unsaved changes before we switch to the new page */
-				const unsavedChangesExist = this.unsavedChangesExist();
-				if (unsavedChangesExist) {
-					this.savePage();
-				}
-				this.setLoaded(false);
-				this.$router.push(`/site/${this.site}/page/${page_id}`);
-				this.$store.commit('changePage', { title: this.page.revision.title, path: this.page.path, slug: this.page.slug } );
+				this.promptToSave(() => {
+					this.setLoaded(false);
+					this.$router.push(`/site/${this.site}/page/${page_id}`);
+					this.$store.commit('changePage', { title: this.page.revision.title, path: this.page.path, slug: this.page.slug } );
+				});
 			}
 			else {
 				this.$snackbar.open({

--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -133,7 +133,8 @@ export default {
 	methods: {
 
 		...mapMutations([
-			'setLoaded'
+			'setLoaded',
+			'updateMenuActive'
 		]),
 
 		...mapActions({
@@ -194,7 +195,7 @@ export default {
 		edit() {
 		    const page_id = this.page.id;
 			if(Number.parseInt(this.$route.params.page_id) !== page_id) {
-				/* autosave any unsaved changes before we switch to the new page */
+				/* prompt to save any unsaved changes before we switch to the new page */
 				this.promptToSave(() => {
 					this.setLoaded(false);
 					this.$router.push(`/site/${this.site}/page/${page_id}`);

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -38,6 +38,7 @@ import Icon from 'components/Icon';
 import { undoStackInstance } from 'plugins/undo-redo';
 import { onKeyDown, onKeyUp } from 'plugins/key-commands';
 import Toolbar from 'components/sidebar/Toolbar';
+import promptToSave from '../mixins/promptToSave';
 
 /* global window, document */
 
@@ -49,6 +50,8 @@ export default {
 		Icon,
 		Toolbar
 	},
+
+	mixins:[ promptToSave ],
 
 	created() {
 		this.onKeyDown = onKeyDown(undoStackInstance);
@@ -90,28 +93,22 @@ export default {
 			'handleSavePage'
 		]),
 
-		/* if user has unsaved changes then save the changes */
-		autoSave() {
-			const unsavedChangesExist = this.unsavedChangesExist();
-			if (unsavedChangesExist) {
-				this.handleSavePage({message: this.$message});
-			}
-		},
-
 		handleCommand(command) {
 			if(command === 'sign-out') {
-				this.autoSave();
-				window.location = '/auth/logout';
+				this.promptToSave(() => {
+					window.location = '/auth/logout';
+				});
 			}
 		},
 
 		backToSites() {
-			this.autoSave();
-			this.$store.commit('changePage', {title: "Home page", path: '/', slug:'home'});
-			this.$store.commit('setPage', {});
-			this.$store.commit('setLoaded', false);
-			undoStackInstance.clear();
-			this.$router.push('/sites');
+			this.promptToSave(() => {
+				this.$store.commit('changePage', {title: "Home page", path: '/', slug:'home'});
+				this.$store.commit('setPage', {});
+				this.$store.commit('setLoaded', false);
+				undoStackInstance.clear();
+				this.$router.push('/sites');
+			})
 		}
 	}
 };

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapActions } from 'vuex';
+import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
 import Icon from 'components/Icon';
 import { undoStackInstance } from 'plugins/undo-redo';
 import { onKeyDown, onKeyUp } from 'plugins/key-commands';
@@ -91,6 +91,10 @@ export default {
 
 		...mapActions([
 			'handleSavePage'
+		]),
+
+		...mapMutations([
+			'updateMenuActive'
 		]),
 
 		handleCommand(command) {

--- a/resources/assets/js/mixins/promptToSave.js
+++ b/resources/assets/js/mixins/promptToSave.js
@@ -1,0 +1,31 @@
+/*
+ mixin for wrapping a set of actions around a prompt to save if the user has unsaved changes on the current page 
+*/
+export default {
+	methods: {
+		/**
+		 * wraps a prompt to save arounds a series of actions 
+		 * @param {function} to be executed if the user elects to ignore unsaved changes - for example to
+		 * leave the current page or log out
+		 */
+		promptToSave(intendedActions) {
+			const unsavedChangesExist = this.unsavedChangesExist();
+			if (unsavedChangesExist) {
+				this.$confirm(`You have unsaved changes, you will lose them if you continue`, 'Warning', {
+					confirmButtonText: 'Continue and lose changes',
+					cancelButtonText: 'Cancel',
+					type: 'warning'
+				}).then(() => {
+					// user decided not to save 
+					intendedActions();
+				}).catch(() => {
+					// decided to remain in the editor
+				});
+			} else {
+				// user had no unsaved changes so proceed with intended actions
+				intendedActions();
+			}
+		},
+	}
+};
+		

--- a/resources/assets/js/mixins/promptToSave.js
+++ b/resources/assets/js/mixins/promptToSave.js
@@ -20,6 +20,9 @@ export default {
 					intendedActions();
 				}).catch(() => {
 					// decided to remain in the editor
+					if (this.activeMenuItem!=='blocks') {
+						this.updateMenuActive('blocks');
+					}
 				});
 			} else {
 				// user had no unsaved changes so proceed with intended actions


### PR DESCRIPTION
I've replaced the autosaving function with a prompt which appears when a user tries to move away from unsaved changes like ...

* clicking the link to the site list
* changing the currently selected page within the editor
* logging out