### PR TITLE
Make login work without redirecting to css and make logout sort-of work

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,4 +44,10 @@ class User extends KentUser
         return ($this->role == 'admin');
     }
 
+    public function setRememberToken($value)
+    {
+        return false;
+    }
+
+
 }

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -39,6 +39,7 @@ import { undoStackInstance } from 'plugins/undo-redo';
 import { onKeyDown, onKeyUp } from 'plugins/key-commands';
 import Toolbar from 'components/sidebar/Toolbar';
 import promptToSave from '../mixins/promptToSave';
+import Config from '../classes/Config.js';
 
 /* global window, document */
 
@@ -100,7 +101,19 @@ export default {
 		handleCommand(command) {
 			if(command === 'sign-out') {
 				this.promptToSave(() => {
-					window.location = '/auth/logout';
+
+                    var form = document.createElement("form");
+                    form.setAttribute("method", 'post');
+                    form.setAttribute("action", Config.get('base_url', '') + '/auth/logout');
+                    var csrf = document.createElement("input");
+                    csrf.setAttribute("type", "hidden");
+                    csrf.setAttribute("name", "_token");
+                    csrf.setAttribute("value", window.astro.csrf_token);
+                    form.appendChild(csrf);
+                    document.body.appendChild(form);
+                    form.submit();
+
+//					window.location = Config.get('base_url', '') + '/auth/logout';
 				});
 			}
 		},

--- a/resources/assets/js/components/sidebar/Toolbar.vue
+++ b/resources/assets/js/components/sidebar/Toolbar.vue
@@ -30,6 +30,7 @@ import { mapState, mapMutations, mapActions } from 'vuex';
 import Icon from 'components/Icon';
 import { undoStackInstance } from 'plugins/undo-redo';
 
+
 export default {
 	name: 'toolbar',
 

--- a/resources/views/inline.blade.php
+++ b/resources/views/inline.blade.php
@@ -10,7 +10,6 @@
 
 	<title>Astro</title>
 
-	<link rel="stylesheet" href="{{ url("/") }}{{ mix('/build/css/vendor.css') }}" />
 	<link rel="stylesheet" href="{{ url("/") }}{{ mix('/build/css/main.css') }}" />
 	@if ($is_preview)
 		<style>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,7 +10,7 @@
 
 	<title>Kent CMS</title>
 
-	<link rel="stylesheet" href="{{ url("/") }}{{ mix('/build/css/vendor.css') }}" />
+
 	<link rel="stylesheet" href="{{ url("/") }}{{ mix('/build/css/main.css') }}" />
 
 	<script>


### PR DESCRIPTION
This fixes the login issue where it redirected to a non-existent css file.

It also sorta-fixes the logout functionality - in that the logout button now posts to logout successfully...

However, as API access is authenticated using a token that never changes, using the back button appears to get the user back into a working version of the editor...