### PR TITLE
Feature/prompt to save fix for duplicated prompt on logout

### DIFF
--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -103,10 +103,6 @@ export default {
 			pageData: state => state.page.pageData
 		}),
 
-		...mapGetters([
-			'unsavedChangesExist'
-		]),
-
 		root() {
 			return this.depth === 0;
 		},

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -75,10 +75,6 @@ export default {
 			pageSlug: state => state.page.pageSlug
 		}),
 
-		...mapGetters([
-			'unsavedChangesExist'
-		]),
-
 		showBack() {
 			return ['site', 'page'].indexOf(this.$route.name) !== -1;
 		},

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -60,6 +60,7 @@ export default {
 
 		document.addEventListener('keydown', this.onKeyDown);
 		document.addEventListener('keyup', this.onKeyUp);
+		window.addEventListener("beforeunload", this.leaveAstro); 
 	},
 
 	destroyed() {
@@ -85,6 +86,15 @@ export default {
 	},
 
 	methods: {
+
+		leaveAstro(e) {
+			/* we are very limited as to what we can do when a tries to leave 
+			https://developer.mozilla.org/en/docs/Web/Events/beforeunload
+			*/
+			var confirmationMessage = "\o/";
+			e.returnValue = confirmationMessage;     // Gecko, Trident, Chrome 34+
+			return confirmationMessage;              // Gecko, WebKit, Chrome <34
+		},
 
 		...mapActions([
 			'handleSavePage'

--- a/resources/assets/js/mixins/promptToSave.js
+++ b/resources/assets/js/mixins/promptToSave.js
@@ -1,8 +1,22 @@
 /*
  mixin for wrapping a set of actions around a prompt to save if the user has unsaved changes on the current page 
 */
+import { mapMutations, mapGetters } from 'vuex';
+
 export default {
+	computed: {
+		...mapGetters([
+			'unsavedChangesExist'
+		]),
+
+		...mapMutations([
+			'resetCurrentSavedState'
+		]),
+	},
+	
 	methods: {
+
+
 		/**
 		 * wraps a prompt to save arounds a series of actions 
 		 * @param {function} to be executed if the user elects to ignore unsaved changes - for example to
@@ -11,18 +25,16 @@ export default {
 		promptToSave(intendedActions) {
 			const unsavedChangesExist = this.unsavedChangesExist();
 			if (unsavedChangesExist) {
-				this.$confirm(`You have unsaved changes, you will lose them if you continue`, 'Warning', {
+				const result = this.$confirm(`You have unsaved changes, you will lose them if you continue`, 'Warning', {
 					confirmButtonText: 'Continue and lose changes',
 					cancelButtonText: 'Cancel',
 					type: 'warning'
 				}).then(() => {
-					// user decided not to save 
+					// user decided not to save so reset the tracking of currently staved state
+					this.$store.commit('resetCurrentSavedState');
 					intendedActions();
-				}).catch(() => {
-					// decided to remain in the editor
-					if (this.activeMenuItem!=='blocks') {
-						this.updateMenuActive('blocks');
-					}
+				}).catch((error) => {
+					// @todo either user cancels or the actions within the then have thrown an exception
 				});
 			} else {
 				// user had no unsaved changes so proceed with intended actions

--- a/resources/assets/js/store/index.js
+++ b/resources/assets/js/store/index.js
@@ -37,9 +37,6 @@ let store = new Vuex.Store({
 		publishModal: {
 			visible: false
 		},
-		unsavedChangesModal: {
-			visible: false
-		},
 		menu: {
 			active: 'pages'
 		}
@@ -104,15 +101,6 @@ let store = new Vuex.Store({
 		hidePublishModal(state) {
 			state.publishModal.visible = false;
 		},
-
-		showUnsavedChangesModal(state) {
-			state.unsavedChangesModal.visible = true;
-		},
-
-		hideUnsavedChangesModal(state) {
-			state.unsavedChangesModal.visible = false;
-		},
-
 		updateMenuActive(state, id) {
 			state.menu.active = id;
 		}

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -275,7 +275,12 @@ const getters = {
 	},
 
 	unsavedChangesExist: (state) => () => {
-		return state.currentSavedState != JSON.stringify(state.pageData.blocks);
+		if (state.currentSavedState.length === 0) {
+	 		// if user has not edited a page yet so we do not have any unsaved changes
+			return false;
+		} else {
+			return state.currentSavedState != JSON.stringify(state.pageData.blocks);
+		}
 	}
 };
 

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -161,6 +161,10 @@ const mutations = {
 
 	updateCurrentSavedState(state) {
 		state.currentSavedState = JSON.stringify(state.pageData.blocks);
+	},
+
+	resetCurrentSavedState(state) {
+		state.currentSavedState = '';	
 	}
 };
 


### PR DESCRIPTION
Fix to make the prompt to save to not repeat asking the user to save changes.

Could be triggered by...

1. edit page
2. click Site List 
3. choose to abandon changes at the prompt
4. click admin -> logout 
and receive a further, unwanted, prompt to save changes 