### PR TITLE
Add unique index to stop two pages with same path existing.

### DIFF
--- a/database/migrations/2017_09_01_090700_add_unique_site_version_path_index_on_pages.php
+++ b/database/migrations/2017_09_01_090700_add_unique_site_version_path_index_on_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUniqueSiteVersionPathIndexOnPages extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->unique(['site_id', 'version', 'path'], 'idx_site_id_version_path2');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->dropUnique('idx_site_id_version_path2');
+        });
+    }
+}


### PR DESCRIPTION
Enforces at database level the condition that paths must be unique for a version of a site.

Matthew and Sam can confirm the need for this...

Could alternately have enforced this on site_id, parent_id, version and slug.