### PR TITLE
Add trusted proxy package to get site editor working behind proxies (…

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends HttpKernel
 		\Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
 		\App\Http\Middleware\TrimStrings::class,
 		\Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \Fideloper\Proxy\TrustProxies::class,
 	];
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
 		"barryvdh/laravel-ide-helper": "^2.3",
 		"baum/baum": "~1.0",
 		"doctrine/dbal": "^2.5",
+		"fideloper/proxy": "^3.3",
 		"intervention/image": "^2.3",
 		"intervention/imagecache": "^2.3",
 		"james-heinrich/getid3": "^1.9",
@@ -39,8 +40,8 @@
 		"rtconner/laravel-tagging": "^2.2",
 		"spatie/laravel-fractal": "^3.5",
 		"spatie/laravel-permission": "^1.12",
-		"unikent/kentauth": "dev-laravel/5.3",
-		"unikent/astro-renderer": "dev-develop"
+		"unikent/astro-renderer": "dev-develop",
+		"unikent/kentauth": "dev-laravel/5.3"
 	},
 	"require-dev": {
 		"fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "efca930e7f6119c645fe9bff1b3fe671",
+    "content-hash": "3a09c1e82b0b04a5c93bbbb878ead2f5",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -776,6 +776,63 @@
                 "parser"
             ],
             "time": "2017-05-14T14:47:48+00:00"
+        },
+        {
+            "name": "fideloper/proxy",
+            "version": "3.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fideloper/TrustedProxy.git",
+                "reference": "9cdf6f118af58d89764249bbcc7bb260c132924f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/9cdf6f118af58d89764249bbcc7bb260c132924f",
+                "reference": "9cdf6f118af58d89764249bbcc7bb260c132924f",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "~5.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "illuminate/http": "~5.0",
+                "mockery/mockery": "~0.9.3",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Fideloper\\Proxy\\TrustedProxyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fideloper\\Proxy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Fidao",
+                    "email": "fideloper@gmail.com"
+                }
+            ],
+            "description": "Set trusted proxies for Laravel",
+            "keywords": [
+                "load balancing",
+                "proxy",
+                "trusted proxy"
+            ],
+            "time": "2017-06-15T17:19:42+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -5252,8 +5309,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "laravel/framework": 20,
-        "unikent/kentauth": 20,
-        "unikent/astro-renderer": 20
+        "unikent/astro-renderer": 20,
+        "unikent/kentauth": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/config/app.php
+++ b/config/app.php
@@ -217,7 +217,7 @@ return [
 		App\Providers\EventServiceProvider::class,
 		App\Providers\RouteServiceProvider::class,
 		// App\Providers\ComposerServiceProvider::class,
-
+        Fideloper\Proxy\TrustedProxyServiceProvider::class,
 	],
 
 	/*

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,69 @@
+<?php
+
+return [
+
+    /*
+     * Set trusted proxy IP addresses.
+     *
+     * Both IPv4 and IPv6 addresses are
+     * supported, along with CIDR notation.
+     *
+     * The "*" character is syntactic sugar
+     * within TrustedProxy to trust any proxy
+     * that connects directly to your server,
+     * a requirement when you cannot know the address
+     * of your proxy (e.g. if using Rackspace balancers).
+     *
+     * The "**" character is syntactic sugar within
+     * TrustedProxy to trust not just any proxy that
+     * connects directly to your server, but also
+     * proxies that connect to those proxies, and all
+     * the way back until you reach the original source
+     * IP. It will mean that $request->getClientIp()
+     * always gets the originating client IP, no matter
+     * how many proxies that client's request has
+     * subsequently passed through.
+     */
+    'proxies' => '*',
+
+    /*
+     * Or, to trust all proxies that connect
+     * directly to your server, uncomment this:
+     */
+     # 'proxies' => '*',
+
+    /*
+     * Or, to trust ALL proxies, including those that
+     * are in a chain of forwarding, uncomment this:
+    */
+    # 'proxies' => '**',
+
+    /*
+     * Default Header Names
+     *
+     * Change these if the proxy does
+     * not send the default header names.
+     *
+     * Note that headers such as X-Forwarded-For
+     * are transformed to HTTP_X_FORWARDED_FOR format.
+     *
+     * The following are Symfony defaults, found in
+     * \Symfony\Component\HttpFoundation\Request::$trustedHeaders
+     *
+     * You may optionally set headers to 'null' here if you'd like
+     * for them to be considered untrusted instead. Ex:
+     *
+     * Illuminate\Http\Request::HEADER_CLIENT_HOST  => null,
+     * 
+     * WARNING: If you're using AWS Elastic Load Balancing or Heroku,
+     * the FORWARDED and X_FORWARDED_HOST headers should be set to null 
+     * as they are currently unsupported there.
+     */
+    'headers' => [
+        (defined('Illuminate\Http\Request::HEADER_FORWARDED') ? Illuminate\Http\Request::HEADER_FORWARDED : 'forwarded') => 'FORWARDED',
+        Illuminate\Http\Request::HEADER_CLIENT_IP    => 'X_FORWARDED_FOR',
+        Illuminate\Http\Request::HEADER_CLIENT_HOST  => 'X_FORWARDED_HOST',
+        Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',
+        Illuminate\Http\Request::HEADER_CLIENT_PORT  => 'X_FORWARDED_PORT',
+    ]
+];


### PR DESCRIPTION
…like on test)

This fix uses the https://github.com/fideloper/TrustedProxy package to add some middleware to the app to "trust" proxy servers (and use their headers such as X_FORWARDED_HOST.

It fixes the issue where on login on our test server users were redirected to the wrong hostname, which was set as part of the "intended" url in the Laravel session.

Please not: there is now a trustedproxies file in the config directory, which is currently set to trust ALL proxies, which may or may not be a bad idea...