### PR TITLE
Feature/console commands to add sites and users

### DIFF
--- a/app/Console/Commands/AddSite.php
+++ b/app/Console/Commands/AddSite.php
@@ -2,7 +2,11 @@
 
 namespace App\Console\Commands;
 
+use App\Models\LocalAPIClient;
+use App\Models\PublishingGroup;
 use Illuminate\Console\Command;
+use Illuminate\Validation\ValidationException;
+use App\Models\User;
 
 class AddSite extends Command
 {
@@ -11,14 +15,20 @@ class AddSite extends Command
      *
      * @var string
      */
-    protected $signature = 'astro:addsite';
+    protected $signature = 'astro:addsite
+                                {publishinggroup : The name of the publishing group for the site.}
+                                {name : The name for the site.}
+                                {host : The host or domain name for the site.}
+                                {path : The root path for the URL for the site.}
+                                {layout : The layout to use for the homepage of the site in the form NAME-VERSION.}
+                                ';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Creates a new site, assigning it to an existing publishing group.';
 
     /**
      * Create a new command instance.
@@ -37,6 +47,39 @@ class AddSite extends Command
      */
     public function handle()
     {
-        //
+        $pg_name = $this->argument('publishinggroup');
+        if(!preg_match('/^[a-z0-9_ -]+$/i', $pg_name)){
+            $this->error('"' . $pg_name . '" is not a valid publishing group name.');
+            return;
+        }
+        $pubgroup = PublishingGroup::where('name', $pg_name)->first();
+        if(!$pubgroup){
+            $pubgroup = PublishingGroup::create([
+               'name' => $pg_name
+            ]);
+            $this->info('Publishing group "'.$pg_name.'" created.');
+        }
+        $name = $this->argument('name');
+        $host = $this->argument('host');
+        $path = $this->argument('path');
+        $layout = $this->argument('layout');
+        if(!preg_match('/^([a-z0-9_-]+)-v([0-9]+)$/i', $layout, $matches)){
+            $this->error('Layout name and version must be provided in the format {layout-name}-v{layout_version}.');
+            return;
+        }
+        $user = User::where('role', 'admin')->first();
+        $api = new LocalAPIClient($user);
+        try{
+            $site = $api->createSite($pubgroup->id, $name, $host, $path, [ 'name' => $matches[1], 'version' => $matches[2] ]);
+            $this->info('Site "'.$site->name.'" created in publishing group "'.$site->publishing_group->name . '"');
+        }catch( ValidationException $e){
+            foreach($e->validator->getMessageBag()->toArray() as $field => $errors){
+                $err = $field . "\n";
+                foreach($errors as $e){
+                    $err .= ' * ' . $e . "\n";
+                }
+                $this->error($err);
+            }
+        }
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,9 @@ class Kernel extends ConsoleKernel
 	 * @var array
 	 */
 	protected $commands = [
-		Commands\CheckDefns::class
+		Commands\CheckDefns::class,
+        Commands\AddSite::class,
+        Commands\AddUser::class,
 	];
 
 	/**

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -88,16 +88,17 @@ const actions = {
 				},
 				title: page.title
 			})
-			.then(() => {
-				dispatch('fetchSite');
+			.then((response) => {
+				page.id = response.data.data.id;
+				dispatch('updatePage', page);
 			})
 	},
 
 	updatePage({ dispatch }, page) {
 		api
-			.patch(`pages/${page.id}/content`, {
-				blocks: page.blocks
-			})
+            .put(`pages/${page.id}/content`, {
+                blocks: page.blocks
+            })
 			.then(() => {
 				dispatch('fetchSite');
 			})


### PR DESCRIPTION
Two commands which can be executed via:

**``astro:addsite <publishinggroup> <name> <host> <path> <layout>``**

Creates a new site, assigning it to a publishing group which will be created if it does not exist.

Arguments:

 * publishinggroup  -     The name of the publishing group for the site.
 * name -                 The name for the site.
 * host -                 The host or domain name for the site.
 * path -                 The root path for the URL for the site.
 * layout -               The layout to use for the homepage of the site in the form NAME-VERSION.

**``astro:adduser <username> <publishinggroup> [<name>] [<email>]``**

 Add a user to a publishing group, creating the user if the account does not exist.

Arguments:
  * username              
  * publishinggroup -      The Publishing Group Name
  * name -                 The users name (only required if the user account does not already exist).
  * email -                The users email (only required if the user account does not already exist).
