### PR TITLE
Allow all users access to all media for now.

### DIFF
--- a/app/Policies/MediaPolicy.php
+++ b/app/Policies/MediaPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Models\APICommands\PublishPage;
 use Gate;
 use App\Models\Site;
 use App\Models\User;
@@ -17,6 +18,8 @@ class MediaPolicy
     {
         if($user->isAdmin())
         {
+            return true;
+        }else{
             return true;
         }
     }
@@ -62,26 +65,22 @@ class MediaPolicy
     /**
      * Determine whether the user can create Media.
      *
-     * Accepts a Media item or an array (a Media instance and a PublishingGroup/Site
-     * instance) as the ACO.
+     * Accepts a Media item and a PublishingGroup or Site instance and uses these to determine whether the user can
+     * upload media.
      *
      * @param  User  $user
      * @param  Media|array $aco
+     * @param Site|PublishingGroup|null Site or Publishing Group
      * @return boolean
      */
-    public function create(User $user, $aco)
+    public function create(User $user, $media, $site_or_pubgroup)
     {
-        if(is_array($aco) && isset($aco[1])){
-            if(is_a($aco[1], Site::class)){
-                return (new SitePolicy)->update($user, $aco[1]);
-
-            } elseif(is_a($aco[1], PublishingGroup::class)){
-                $pgs = $user->publishing_groups->keyBy($aco[1]->getKeyName());
-                return $pgs->has($aco[1]->getKey());
-
-            }
+        if( is_a($site_or_pubgroup, Site::class)){
+            return (new SitePolicy)->update($user, $site_or_pubgroup);
+        } elseif( is_a($site_or_pubgroup, PublishingGroup::class)) {
+            $pgs = $user->publishing_groups->keyBy($site_or_pubgroup->getKeyName());
+            return $pgs->has($site_or_pubgroup->getKey());
         }
-
         return false;
     }
 


### PR DESCRIPTION
The existing MediaPolicy is broken and dissallows all non-admins from viewing media in media library or uploading new media.

This hacky hotfix just always returns true from the MediaPolicy.