### PR TITLE
Automatically create a publishing group for each new user named after their username and add them to it.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,7 +14,7 @@ class User extends KentUser
         'settings' => 'json'
     ];
 
-	protected $hidden = [ 'api_token', 'created_at', 'updated_at', 'created_by', 'updated_by' ];
+	protected $hidden = [ 'api_token', 'created_at', 'updated_at'];
 
     protected $attributes = [
         'settings' => '{}'
@@ -44,8 +44,8 @@ class User extends KentUser
             $group = PublishingGroup::where('name', '=', $user->username)->first();
             if(!$group){
                 $group = PublishingGroup::create(['name' => $user->username]);
-                $group->users()->sync($user, false);
             }
+            $group->users()->sync($user, false);
         });
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -33,6 +33,22 @@ class User extends KentUser
    		$this->api_token = $this->api_token ?: str_random(191); // Max string length without MySQL 5.7, see commit 7c90098
 	}
 
+    /**
+     * Register callback to ensure user has a publishing group with their username.
+     */
+    protected static function boot()
+    {
+        parent::boot();
+        static::created(function($user){
+            // We want every user to automatically have a publishing group with their username.
+            $group = PublishingGroup::where('name', '=', $user->username)->first();
+            if(!$group){
+                $group = PublishingGroup::create(['name' => $user->username]);
+                $group->users()->sync($user, false);
+            }
+        });
+    }
+
     public function publishing_groups()
     {
         return $this->belongsToMany(PublishingGroup::class, 'publishing_groups_users');

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Tests\Unit\Models;
 
+use App\Models\PublishingGroup;
 use Tests\TestCase;
 use App\Models\User;
 
@@ -25,4 +26,12 @@ class UserTest extends TestCase
 		$this->assertTrue($user->isAdmin());
 	}
 
+    /**
+     * @test
+     */
+	public function user_creation_creates_a_publishing_group_with_users_username_and_puts_user_in_it()
+    {
+        $user = factory(User::class)->create();
+        $this->assertInstanceOf(PublishingGroup::class, PublishingGroup::where('name', '=', $user->username)->first());
+    }
 }


### PR DESCRIPTION
We do not currently have a ui for managing users and publishing groups.

For UAT we need admins to be able to create sites for users that only those users can edit.

This feature automatically creates a publishing group when a user record is created, giving it the username
of the user, and adds the user to it.

If the group already exists, the user is added to the existing group and no new group is created.

The artisan console command astro:adduser has been updated to make group name optional. If the user account
already exists and no group name is added it creates (if it does not exist) a group with the user's username
and adds them to it (so can be used to update existing user accounts on the test server).