### PR TITLE
Save pages even if invalid, but only publish if valid.

### DIFF
--- a/app/Http/Transformers/Api/v1/PageTransformer.php
+++ b/app/Http/Transformers/Api/v1/PageTransformer.php
@@ -44,7 +44,8 @@ class PageTransformer extends FractalTransformer
             'depth' => $page->depth,
             'parent_id' => $page->parent_id,
             'site_id' => $page->site_id,
-            'revision_id' => $page->revision_id
+            'revision_id' => $page->revision_id,
+			'valid' => $page->revision->valid
         ];
 		if($this->full){
             $data['blocks'] = $page->revision->blocks;

--- a/app/Models/APICommands/AddPage.php
+++ b/app/Models/APICommands/AddPage.php
@@ -72,7 +72,8 @@ class AddPage implements APICommand
             'layout_name' => $layout_name,
             'layout_version' => $layout_version,
             'blocks' => null,
-            'options' => null
+            'options' => null,
+			'valid' => true
         ]);
         $page->setRevision($revision);
         return $page;

--- a/app/Models/APICommands/CreateSite.php
+++ b/app/Models/APICommands/CreateSite.php
@@ -63,7 +63,8 @@ class CreateSite implements APICommand
             'created_by' => $user->id,
             'updated_by' => $user->id,
             'layout_name' => $layout['name'],
-            'layout_version' => $layout['version']
+            'layout_version' => $layout['version'],
+			'valid' => true
         ]);
         $page->setRevision($revision);
         $page->refresh();

--- a/app/Models/APICommands/PublishPage.php
+++ b/app/Models/APICommands/PublishPage.php
@@ -202,7 +202,8 @@ class PublishPage implements APICommand
         return [
           'id' => [
               'exists:pages,id',
-              'parent_is_published:'.$data->get('id')
+              'parent_is_published:'.$data->get('id'),
+			  'page_is_valid'
           ],
         ];
     }

--- a/app/Models/APICommands/UpdatePage.php
+++ b/app/Models/APICommands/UpdatePage.php
@@ -47,7 +47,8 @@ class UpdatePage implements APICommand
                 'created_by' => $user->id,
                 'updated_by' => $user->id,
                 'options' => $options,
-                'blocks' => $previous_revision->bake
+                'blocks' => $previous_revision->bake,
+				'valid' => $previous_revision->valid
             ]);
             $page->setRevision($revision);
             $page->fresh();

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -19,6 +19,7 @@ class Block extends Model
 
 	protected $casts = [
 		'fields' => 'json',
+		'errors' => 'json'
 	];
 
 	protected $definition = null;

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -108,7 +108,8 @@ class Page extends BaumNode
                     'definition_name' => $block->definition_name,
                     'definition_version' => $block->definition_version,
                     'region_name' => $block->region_name,
-                    'fields' => $block->fields
+                    'fields' => $block->fields,
+					'errors' => $block->errors
                 ];
             }
         }

--- a/app/Models/Revision.php
+++ b/app/Models/Revision.php
@@ -35,7 +35,8 @@ class Revision extends Model
         'layout_name',
         'layout_version',
         'revision_set_id',
-		'bake'
+		'bake',
+		'valid'
 	];
 
 	protected $dates = [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,6 +25,12 @@ class AppServiceProvider extends ServiceProvider
 		Schema::defaultStringLength(191); // Fix for the webfarm running older MySQL
 
         Validator::extend('parent_is_published', function( $attr, $value ) { return PublishPage::canBePublished($value); });
+
+        Validator::extend('page_is_valid', function($attr, $id) {
+        	$page = Page::find($id);
+        	return $page && $page->revision->valid;
+		});
+
         Validator::extend('unique_site_path', function($attr, $value, $parameters, $validator) {
             $host = isset($parameters[0]) ? $parameters[0] : null;
             return (new UniqueSitePathRule($host))->passes($attr, $value);

--- a/database/migrations/2017_09_20_112547_add_errors_to_blocks.php
+++ b/database/migrations/2017_09_20_112547_add_errors_to_blocks.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddErrorsToBlocks extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('blocks', function (Blueprint $table) {
+            $table->mediumText('errors')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('blocks', function (Blueprint $table) {
+            $table->dropColumn('errors');
+        });
+    }
+}

--- a/database/migrations/2017_09_20_112625_add_valid_state_to_revisions.php
+++ b/database/migrations/2017_09_20_112625_add_valid_state_to_revisions.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddValidStateToRevisions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('revisions', function (Blueprint $table) {
+            $table->boolean('valid')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('revisions', function (Blueprint $table) {
+            $table->dropColumn('valid');
+        });
+    }
+}


### PR DESCRIPTION
This merge request:
  - Ignores block-level validation errors when saving a page (but still enforces the region-block-level validation).
  - Stores any block-level validation errors with the blocks themselves, in an "errors" field for each block which is included when a page and its blocks are sent as json.
  - Adds a "valid" property on each revision, which is included in the json for a Page as a "valid" field.
  - Enforces the rule that all blocks must be valid before PUBLISHING a page.