### PR TITLE
Fix for errors not always being returned from the API when loading a …

### DIFF
--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import Vue from 'vue';
-import { mapMutations } from 'vuex';
 import { Definition } from 'classes/helpers';
 import api from 'plugins/http/api';
 import { undoStackInstance } from 'plugins/undo-redo';
@@ -247,8 +246,8 @@ const actions = {
 						});
 
 						Object.keys(blocks).forEach(region => {
-							blocks[region].forEach((block, index) => {
-								if (block.errors !== null) {
+							blocks[region].forEach((block) => {
+								if (typeof block.errors !== 'undefined' && block.errors !== null) {
 									commit('addBlockValidationIssue', block.id);
 								}
 							});


### PR DESCRIPTION
…page which led to incorrect error counts on existing pages

This fixes the issue where on page load a block as assumed to have errors when the errors element didn't exist at all. 

@sy238-unikent - can you check this with your existing sites? I've not got a database old enough on my machine to really check this. 