### PR TITLE
Fix/remove validaiton errors when the block is deleted

### DIFF
--- a/resources/assets/js/components/BlockOptions.vue
+++ b/resources/assets/js/components/BlockOptions.vue
@@ -175,14 +175,6 @@ export default {
 				this.$refs['options-list'].scrollTop = 0;
 			}
 		},
-
-		valid(isValid) {
-			if (isValid) {
-				this.deleteBlockValidationIssue(this.currentBlock.id);
-			} else {
-				this.addBlockValidationIssue(this.currentBlock.id);
-			}
-		}
 	},
 
 	methods: {
@@ -251,7 +243,11 @@ export default {
 		},
 
 		setValidation(status) {
-			this.valid = status;
+			if (status) {
+				this.deleteBlockValidationIssue(this.currentBlock.id);
+			} else {
+				this.addBlockValidationIssue(this.currentBlock.id);
+			}
 		}
 
 	}

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -184,8 +184,7 @@ const mutations = {
 	deleteBlockValidationIssue(state, block_id) {
 		const location = state.invalidBlocks.indexOf(block_id);
 		if (location !== -1) {
-			reducedItems = state.invalidBlocks.splice(location, 1);
-			state.invalidBlocks = reducedItems;
+			state.invalidBlocks.splice(location, 1);
 		}
 	},
 
@@ -237,7 +236,7 @@ const actions = {
 						});
 
 						Object.keys(blocks).forEach(region => {
-							blocks[region].forEach((block, index) => {
+							blocks[region].forEach((block) => {
 								if (block.errors !== null) {
 									commit('addBlockValidationIssue', block.id);
 								}
@@ -245,8 +244,6 @@ const actions = {
 						});
 
 						commit('setLoaded');
-						// @TODO - populate validations issues with those received from the api
-
 					});
 
 			});
@@ -372,6 +369,10 @@ const getters = {
 	getBlockMeta: (state) => (index, region, prop = false) => {
 		const blockMeta = state.blockMeta.blocks[region][index];
 		return prop ? blockMeta[prop] : blockMeta;
+	},
+
+	getBlocks: (state) => () => {
+		return state.pageData.blocks;
 	},
 
 	scaleDown: (state) => () => {

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -101,7 +101,8 @@ export default {
 
 		...mapGetters([
 			'scaleDown',
-			'scaleUp'
+			'scaleUp',
+			'getBlocks'
 		]),
 
 		layout() {
@@ -191,7 +192,8 @@ export default {
 			'addBlock',
 			'showBlockPicker',
 			'updateInsertIndex',
-			'updateInsertRegion'
+			'updateInsertRegion',
+			'deleteBlockValidationIssue'
 		]),
 
 		initEvents() {
@@ -218,7 +220,11 @@ export default {
 		},
 
 		removeBlock(command) {
+			// remove block but before we do so remove any validation issues it owns 
 			const { index, region } = this.current;
+			const blocks = this.getBlocks();
+			const blockToBeDeleted = blocks[region][index];
+			this.deleteBlockValidationIssue(blockToBeDeleted.id);
 			this.deleteBlock({ index, region });
 			this.hideOverlay();
 			this.current = null;


### PR DESCRIPTION
This is a fix for https://github.com/unikent/astro/issues/93 which also fixes the eslint issue to do with not explicitly declaring a variable. 

[1] Added a getter for Blocks in page.js

[2] Simplified how BlockOptions deals with validation messages emitted from the BlockForm. The function called when the messages are received now directly calls the mutators for the invalidBlocks array. Previous, it was setting a variable in the component which was being watched buy something which called the mutators. I'm not sure what I was thinking when I implemented it that way originally...

[3] Removing a block now calls the mutator for removing a member of the invalidBlocks array to remove any trace of validation issues belonging to that block. (which is why I needed [1])