### PR TITLE
Marking this test as incomplete since we have not decided what we are…

### DIFF
--- a/tests/Unit/Policies/PublishingGroupPolicyTest.php
+++ b/tests/Unit/Policies/PublishingGroupPolicyTest.php
@@ -21,11 +21,12 @@ class PublishingGroupPolicyTest extends PolicyTestCase
     /**
      * @test
      * @group authorization
-     */
+     * 
+     */ 
     public function index_WhenUserIsNotAdmin_IsDenied(){
-        $user = factory(User::class)->make([ 'role' => 'user' ]);
-        $this->assertPolicyDenies(new PublishingGroupPolicy, 'index', $user, PublishingGroup::class);
+        // $user = factory(User::class)->make([ 'role' => 'user' ]);
+        // $this->assertPolicyDenies(new PublishingGroupPolicy, 'index', $user, PublishingGroup::class);
+        $this->markTestIncomplete('This requires further work on permission model');
     }
-
 
 }


### PR DESCRIPTION
… doing about this permission yet

We had been restricting access to the list of publishing groups to admins only.
However, on the test site we are currently allowing users to create sites and doing that required access to the list of publishing groups.

I've marked a test about this incomplete until we have come up with the plan for the permissions.