### PR TITLE
Feature/jump to field

### DIFF
--- a/resources/assets/js/components/BlockOptions.vue
+++ b/resources/assets/js/components/BlockOptions.vue
@@ -6,7 +6,7 @@
 				currentDefinition.label : title
 		"
 	 />
-	<div ref="options-list" class="block-options-list custom-scrollbar">
+	<div ref="options-list" id="block-options-list" class="block-options-list custom-scrollbar">
 		<block-form
 			v-if="currentDefinition"
 			v-on:failValidation="setValidation(false)"

--- a/resources/assets/js/components/sidebar/Errors.vue
+++ b/resources/assets/js/components/sidebar/Errors.vue
@@ -8,7 +8,7 @@
 					<template v-if="errors.indexOf(block.id) !== -1">
 						<li class="validation-errors__item warning">
 							<i class="el-icon-warning"></i>
-							<a href="#" @click="scrollTo(key)" class="validation-errors__link">{{ label(block.definition_name + "-v" + block.definition_version) }}</a>
+							<a href="#" @click="scrollTo(key, block.definition_name, block.definition_version)" class="validation-errors__link">{{ label(block.definition_name + "-v" + block.definition_version) }}</a>
 						</li>
 					</template>
 				</template>
@@ -58,7 +58,7 @@ export default {
 		- note that blocks are identified by their block position and not unique api id.
 		- this means as blocks are reordered on the page, the error markers automatically reposition accordingly
 		*/
-		scrollTo(block_id) {
+		scrollTo(block_id, definition_name, definition_version) {
 			var el = document.getElementById('editor-content');
 			var block = el.contentWindow.document.getElementById('block_' + block_id);
 			// position of the block in the iframe
@@ -66,8 +66,9 @@ export default {
 			// add on Y scroll position to pos.top to make sure the position for the next jump is relative to the current scroll position
 			el.contentWindow.scrollTo(0, pos.top + el.contentWindow.scrollY);
 
-			// set the current block
-			this.setBlock({ index: block_id, type: 'type' });
+			// set the current block, given its position (index) and name (definition_name + definition_version)
+			var type = definition_name + "-v" + definition_version;
+			this.setBlock({ index: block_id, type: type });
 
 			// set the block menu item as active
 			this.updateMenuActive('blocks');

--- a/resources/assets/js/components/sidebar/Errors.vue
+++ b/resources/assets/js/components/sidebar/Errors.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapMutations } from 'vuex';
 import BackBar from 'components/BackBar';
 
 export default {
@@ -47,6 +47,11 @@ export default {
 
 	methods: {
 
+		...mapMutations([
+			'setBlock',
+			'updateMenuActive'
+		]),
+
 		/**
 		@TODO - implement smooth scrolling?
 		scrollTo() - simple jump to the specified block in the iframe 'editor-content'
@@ -60,6 +65,12 @@ export default {
 			var pos = block.getBoundingClientRect();
 			// add on Y scroll position to pos.top to make sure the position for the next jump is relative to the current scroll position
 			el.contentWindow.scrollTo(0, pos.top + el.contentWindow.scrollY);
+
+			// set the current block
+			this.setBlock({ index: block_id, type: 'type' });
+
+			// set the block menu item as active
+			this.updateMenuActive('blocks');
 		},
 
 		// return the correct human-readable label for the specified block definition

--- a/resources/assets/js/components/sidebar/Errors.vue
+++ b/resources/assets/js/components/sidebar/Errors.vue
@@ -72,6 +72,26 @@ export default {
 
 			// set the block menu item as active
 			this.updateMenuActive('blocks');
+
+			// scroll to the right bit of the block options side panel
+			// we need a tiny timeout to make sure the error fields have had time to populate
+			setTimeout( () => {
+			
+				// find all the error fields...
+				var error_fields = document.getElementsByClassName('is-error');
+
+				// ...and get the block options list containing div
+				var options_list = document.getElementById('block-options-list');
+
+				// Now get the top/bottom of the first error
+				// we need to add on the top position of the scroll to make sure the next time we're not going to go back to the top of the div
+				var error_pos_top = error_fields[0].getBoundingClientRect().top + options_list.scrollTop;
+				var error_pos_bottom = error_fields[0].getBoundingClientRect().bottom + options_list.scrollTop;
+
+				// and finally scroll to the position of the error, adding on a bit to make sure it's properly visible
+				options_list.scrollTop = error_pos_top - (error_pos_bottom - error_pos_top) - 50;
+			}, 1);
+
 		},
 
 		// return the correct human-readable label for the specified block definition


### PR DESCRIPTION
If the user clicks the block error in the error sidebar, they jump to the specified block, get shown the block fields, and then jumped to the first error field in that block