### PR TITLE
Feature/automatic suggested slug on page creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "scribe-plugin-link-prompt-command": "^1.0.0",
     "scribe-plugin-sanitizer": "^0.1.10",
     "sinon": "^2.2.0",
+    "underscore.string": "^3.3.4",
     "vue": "^2.1.0",
     "vue-chartjs": "^2.3.9",
     "vue-router": "^2.2.0",

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -20,7 +20,11 @@
 			<el-input name="layout_version" v-model="createForm.layout_version" auto-complete="off"></el-input>
 		</el-form-item>
 		<el-form-item label="slug">
-			<el-input name="slug" v-model="createForm.route.slug" auto-complete="off"></el-input>
+			<el-input 
+				name="slug"
+				v-model="createForm.route.slug"
+				v-bind:placeholder="suggestedSlug" 
+				auto-complete="off" @focus="setUserEditingSlug"></el-input>
 		</el-form-item>
 	</el-form>
 	<span slot="footer" class="dialog-footer">
@@ -33,6 +37,7 @@
 <script>
 import { mapState, mapActions } from 'vuex';
 import { Definition } from 'classes/helpers';
+import { slugify } from 'underscore.string';
 
 export default {
 
@@ -59,12 +64,13 @@ export default {
 				layout_name: 'site-homepage',
 				layout_version: 1,
 				route: {
-					slug: 'newpage',
+					slug: '',
 					parent_id: 1
 				},
 				blocks: {},
 				options: {}
-			}
+			},
+			userEditingSlug: false
 		};
 	},
 
@@ -85,6 +91,10 @@ export default {
 				}
 			}
 		},
+
+		suggestedSlug() {
+			return slugify(this.createForm.title);
+		}
 	},
 
 	created() {
@@ -100,8 +110,34 @@ export default {
 		}),
 
 		addChild() {
+			// if the user has not edited the slug then use the suggested slug
+			if (this.userEditingSlug ==  false) {
+				this.createForm.route.slug = this.suggestedSlug;
+			}
 			this.createPage(this.createForm);
+			this.resetForm();
 			this.visible = false;
+		},
+
+		setUserEditingSlug() {
+			if (this.userEditingSlug ==  false) {
+				this.userEditingSlug = true;
+				this.createForm.route.slug = this.suggestedSlug;
+			}
+		},
+
+		resetForm() {
+			this.createForm = {
+				title: 'New page',
+				layout_name: 'site-homepage',
+				layout_version: 1,
+				route: {
+					slug: '',
+					parent_id: 1
+				},
+				blocks: {},
+				options: {}
+			}
 		},
 
 		saveEdit() {

--- a/resources/assets/js/plugins/http/interceptors.js
+++ b/resources/assets/js/plugins/http/interceptors.js
@@ -19,11 +19,11 @@ export default (http, store, router) => {
 							response.data.errors.forEach(error => {
 
 								// notification to the user
-								vue.$notify({
-									title: 'Error',
-									message: 'There are some problems on your page.' + error,
-									type: 'error'
-								});
+								// vue.$notify({
+								// 	title: 'Error',
+								// 	message: 'There are some problems on your page.' + error,
+								// 	type: 'error'
+								// });
 
 								if(error.details && typeof error.details === 'object') {
 

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -127,6 +127,14 @@ const actions = {
 				page.id = response.data.data.id;
 				dispatch('updatePage', page);
 			})
+			.catch((error) => {
+				vue.$notify({
+					title: 'Page not added',
+					message: 'Please ensure that there is not already a page with the same slug',
+					type: 'error',
+					duration: 0
+				});
+			})
 	},
 
 	updatePage({ dispatch }, page) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6898,6 +6898,10 @@ split-string@^3.0.1:
   dependencies:
     extend-shallow "^2.0.1"
 
+sprintf-js@^1.0.3:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -7403,6 +7407,13 @@ unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
+underscore.string@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
+  dependencies:
+    sprintf-js "^1.0.3"
+    util-deprecate "^1.0.2"
+
 underscore.string@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.2.3.tgz#806992633665d5e5fcb4db1fb3a862eb68e9e6da"
@@ -7554,7 +7565,7 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
* Create Page dialogue now has a suggested page slug based on the page title. This uses the [underscore.string](http://epeli.github.io/underscore.string/) slugify function we use in account.kent https://trello.com/c/REXY3MGS

* I have commented out the default generic error message from the http interceptor since this is too generic for 422 errors from the create page. I think we need to figure out a less generic way to do this, or at least be able to suppress the default error when we need.
