### PR TITLE
Feature/link from save validation warning to error sidebar

### DIFF
--- a/resources/assets/js/components/sidebar/index.vue
+++ b/resources/assets/js/components/sidebar/index.vue
@@ -185,7 +185,7 @@ export default {
 	mounted() {
 		// to enable other components to open the errors sidebar when needed
 		eventBus.$on('sidebar:openErrors', (e) => {
-			this.openItem(e, 2);
+			this.updateMenuActive('errors');
 		});
 	}
 };

--- a/resources/assets/js/components/sidebar/index.vue
+++ b/resources/assets/js/components/sidebar/index.vue
@@ -83,7 +83,7 @@ import Navigation from 'components/sidebar/Navigation';
 import Settings from 'components/sidebar/Settings';
 import HelpCentre from 'components/sidebar/HelpCentre';
 import ErrorSidebar from 'components/sidebar/Errors';
-
+import { eventBus } from 'plugins/eventbus';
 import { clamp } from 'classes/helpers';
 
 /* global document */
@@ -180,6 +180,13 @@ export default {
 			this.collapseSidebar();
 			this.updateMenuActive(this.menu[index].id);
 		}
+	},
+
+	mounted() {
+		// to enable other components to open the errors sidebar when needed
+		eventBus.$on('sidebar:openErrors', (e) => {
+			this.openItem(e, 2);
+		});
 	}
 };
 </script>

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -40,6 +40,13 @@ const state = {
 	invalidBlocks: []
 };
 
+
+methods : {
+	closeNotification: () => {
+		vue.$notify.close();
+	}
+}
+
 const mutations = {
 	/**
 	 * Mutation to set the current page.
@@ -277,20 +284,38 @@ const actions = {
 					// there are validation errors
 					if (response.data.data.valid===0) {
 						// create the message markup
+
 						const message = vue.$createElement(
 							'div',
-							{ style: 'color: #bb9132' },
+							{ 
+								'style': { 
+									color: '#bb9132'
+								},
+							},
 							[
 								vue.$createElement('p', 'The page saved ok, but there are some validation errors.'),
 								vue.$createElement('p', 'You won\'t be able to publish till these are fixed.'),
-								vue.$createElement('p', 'Check the error sidebar for details.')
-							]
+								vue.$createElement('a', {
+									attrs: {
+										href: '#'
+									},
+									on: {
+										click(e) {
+											eventBus.$emit('sidebar:openErrors', e);
+										}
+									}
+								}, 'Check the error sidebar for details.')
+							],
+							
 						);
 						vue.$notify({
 							title: 'Saved',
 							message: message,
 							type: 'warning',
-							duration: 10000
+							duration: 10000,
+							onClick: function() {
+								this.close();
+							}
 						});
 					}
 					// we're all good

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -40,13 +40,6 @@ const state = {
 	invalidBlocks: []
 };
 
-
-methods : {
-	closeNotification: () => {
-		vue.$notify.close();
-	}
-}
-
 const mutations = {
 	/**
 	 * Mutation to set the current page.


### PR DESCRIPTION
Added a link from the "Save with validation warnings" version of the save notification.

Clicking the link fires an event on the eventbus which is listened to by the sidebar/index which switches the selected sidebar to the validation issues list. 

This is for item 'Implement link on save modal, when validation issues' on https://trello.com/c/XfSzG7oL