### PR TITLE
Change the way validation rules are loaded (they are now eager loaded…

### DIFF
--- a/resources/assets/js/classes/Definition.js
+++ b/resources/assets/js/classes/Definition.js
@@ -33,6 +33,7 @@ export default class Definition {
 	};
 
 	static definitions = {};
+	static rules = {};
 
 	static set(definition) {
 		const type = Definition.getType(definition);
@@ -43,6 +44,7 @@ export default class Definition {
 
 		if(Definition.definitions[type] === void 0) {
 			Definition.definitions[type] = definition;
+			Definition.rules[type] = this.getRules(definition);
 		}
 	}
 
@@ -282,6 +284,12 @@ export default class Definition {
 	}
 
 	static getRules(definition, includeNestedRules = true) {
+		const type = Definition.getType(definition);
+
+		if(Definition.rules[type]) {
+			return Definition.rules[type];
+		}
+
 		let rules = {};
 
 		definition.fields.forEach(field => {

--- a/resources/assets/js/components/BlockOptions.vue
+++ b/resources/assets/js/components/BlockOptions.vue
@@ -100,11 +100,6 @@ import BlockForm from './BlockForm';
 /* global document */
 
 export default {
-	data: function () {
-			return {
-				valid: true
-			}
-		},
 
 	name: 'block-options',
 
@@ -112,12 +107,11 @@ export default {
 
 	components: {
 		Icon,
-		BackBar
+		BackBar,
+		BlockForm
 	},
 
 	computed: {
-
-
 		...mapGetters([
 			'getCurrentBlock'
 		]),
@@ -158,7 +152,10 @@ export default {
 				this.errors.blocks[this.currentRegion][this.currentIndex].fields : {};
 		},
 
-		// @TODO - this lags when switching blocks with different rule sets- investigate
+		// TODO: move validation outside of element
+		// This component used to hang briefly while the validation rules were
+		// being transformed... this now happens when the definitions are first
+		// loaded and the rules are cached.
 		rules() {
 			return Definition.getRules(this.currentDefinition, false);
 		}
@@ -243,9 +240,10 @@ export default {
 		},
 
 		setValidation(status) {
-			if (status) {
+			if(status) {
 				this.deleteBlockValidationIssue(this.currentBlock.id);
-			} else {
+			}
+			else {
 				this.addBlockValidationIssue(this.currentBlock.id);
 			}
 		}


### PR DESCRIPTION
… when the definition is pulled in).

This change makes moving the validation outside of Element UI pretty easy as well.