### PR TITLE
Temporarily disable eager loading validation.

### DIFF
--- a/resources/assets/js/classes/Definition.js
+++ b/resources/assets/js/classes/Definition.js
@@ -284,11 +284,11 @@ export default class Definition {
 	}
 
 	static getRules(definition, includeNestedRules = true) {
-		const type = Definition.getType(definition);
+		// const type = Definition.getType(definition);
 
-		if(Definition.rules[type]) {
-			return Definition.rules[type];
-		}
+		// if(Definition.rules[type]) {
+		// 	return Definition.rules[type];
+		// }
 
 		let rules = {};
 


### PR DESCRIPTION
It doesn't seem like Element UI handles nested validation very well (which is why I didn't take this approach initially, I'd just forgotten).
We can re-enable this once the validation is moved out of Element.