### PR TITLE
 Modify draft preview route so menu link and potentially other links can be modified by renderer in preview mode.

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\LocalAPIClient;
+use App\Models\Page;
+use Astro\Renderer\AstroRenderer;
+use Astro\Renderer\Base\SingleDefinitionsFolderLocator;
+use Astro\Renderer\Engines\TwigEngine;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Renders pages in draft of published mode for previewing in the editor.
+ * @package App\Http\Controllers
+ */
+class PageController extends Controller
+{
+	use AuthorizesRequests, DispatchesJobs;
+
+	public function __construct()
+	{
+		parent::__construct();
+		$this->middleware('auth');
+	}
+
+	/**
+	 * Render a draft page.
+	 * GET /path/to/editor/draft/{host}/{path}
+	 * @param string $host - The "real" domain name for the site
+	 * @param string $path - The full path to the current page.
+	 * @return string - Rendered page HTML with "preview bar" injected.
+	 */
+	public function draft($host, $path = '')
+	{
+		$original_html = $this->renderRoute($host, $path, Page::STATE_DRAFT);
+		$preview_bar = file_get_contents(resource_path('views/components/preview-bar.html'));
+		return preg_replace('/(<body[^>]*>)/is', '$1' . $preview_bar, $original_html, 1);
+	}
+
+	/**
+	 * Render a published page.
+	 * GET /path/to/editor/published/{host}/{path}
+	 * @param string $host - The "real" domain name for the site
+	 * @param string $path - The full path to the current page.
+	 * @return string - Rendered page HTML
+	 */
+	public function published($host, $path = '')
+	{
+		return $this->renderRoute($host, $path, Page::STATE_PUBLISHED);
+	}
+
+	/**
+	 * Use the Renderer to render the Page at a url for a version (draft, published) of a site.
+	 * @param string $host - The "real" domain name for the site
+	 * @param string $path - The full path to the current page.
+	 * @param string $version -  The version of the site to render ('draft', 'published')
+	 * @return string - The rendered HTML output.
+	 */
+	public function renderRoute($host, $path, $version)
+	{
+		$path = '/' . $path;
+		$locator = new SingleDefinitionsFolderLocator(
+			Config::get('app.definitions_path') ,
+			'Astro\Renderer\Base\Block',
+			'Astro\Renderer\Base\Layout'
+		);
+		$api = new LocalAPIClient();
+		$engine = new TwigEngine(Config::get('app.definitions_path'));
+
+		// controller
+		$astro = new AstroRenderer();
+		return $astro->renderRoute($host, $path, $api, $engine, $locator, $version);
+	}
+}

--- a/resources/assets/js/components/PublishModal.vue
+++ b/resources/assets/js/components/PublishModal.vue
@@ -98,6 +98,7 @@ export default {
 		]),
 
 		...mapGetters([
+			'publishedPreviewURL',
 			'pageTitle',
 			'pagePath',
 			'pageSlug',
@@ -121,7 +122,8 @@ export default {
 		},
 		// frontend URL - so the user can view their newly-published page
 		renderedURL() {
-			return `${Config.get('base_url', '')}` + '/published/' + this.siteDomain + this.sitePath + this.pagePath;
+			return this.publishedPreviewURL;
+//			return `${Config.get('base_url', '')}` + '/published/' + this.siteDomain + this.sitePath + this.pagePath;
 		}
 	},
 

--- a/resources/assets/js/components/PublishModal.vue
+++ b/resources/assets/js/components/PublishModal.vue
@@ -123,7 +123,6 @@ export default {
 		// frontend URL - so the user can view their newly-published page
 		renderedURL() {
 			return this.publishedPreviewURL;
-//			return `${Config.get('base_url', '')}` + '/published/' + this.siteDomain + this.sitePath + this.pagePath;
 		}
 	},
 

--- a/resources/assets/js/components/Toolbar.vue
+++ b/resources/assets/js/components/Toolbar.vue
@@ -69,7 +69,8 @@ export default {
 		}),
 
 		...mapGetters([
-			'getInvalidBlocks'
+			'getInvalidBlocks',
+			'draftPreviewURL'
 		]),
 
 		view: {
@@ -82,7 +83,7 @@ export default {
 		},
 
 		draftLink() {
-			return `${Config.get('base_url', '')}/draft/${this.$route.params.page_id}`;
+			return this.draftPreviewURL;
 		},
 
 		invalidBlocks() {

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -3,6 +3,7 @@ import Vue from 'vue';
 import { Definition } from 'classes/helpers';
 import api from 'plugins/http/api';
 import { eventBus } from 'plugins/eventbus';
+import Config from 'classes/Config';
 
 const vue = new Vue();
 
@@ -414,6 +415,26 @@ const getters = {
 	 */
 	currentPage: (state) => {
 		return state.pageData;
+	},
+
+	/**
+	 * Get the URL at which the current page can be previewed in the editor.
+	 * @param state
+	 * @param getters
+	 * @returns {string} Full URL
+	 */
+	draftPreviewURL: (state, getters) => {
+		return `${Config.get('base_url', '')}` + '/draft/' + getters.siteDomain + getters.sitePath + getters.pagePath;
+	},
+
+	/**
+	 * Get the URL at which the published version of the current page can be previewed in the editor.
+	 * @param state
+	 * @param getters
+	 * @returns {string} Full URL
+	 */
+	publishedPreviewURL: (state, getters) => {
+		return `${Config.get('base_url', '')}` + '/published/' + getters.siteDomain + getters.sitePath + getters.pagePath;
 	},
 
 	getFieldValue: (state) => (index, name) => {

--- a/resources/assets/js/views/MenuEditor.vue
+++ b/resources/assets/js/views/MenuEditor.vue
@@ -112,7 +112,6 @@
  * }
  */
 import Schema from 'async-validator';
-
 import Icon from 'components/Icon';
 import Draggable from 'vuedraggable';
 import ScrollInput from 'components/ScrollInput';
@@ -218,6 +217,7 @@ export default {
 	},
 
 	computed: {
+
 		status() {
 			return (
 				// if unsaved but is the same as published menu, treat as draft
@@ -238,7 +238,7 @@ export default {
 	},
 
 	methods: {
-
+		// TODO move this outside of component, store current site data in state
 		fetchSiteData() {
 			this.$api
 				.get(`sites/${this.$route.params.site_id}?include=pages`)
@@ -253,6 +253,8 @@ export default {
 						title: json.data.name,
 						// TODO: don't hardcode HTTPS
 						path: 'https://' + json.data.host + json.data.path,
+						definedHost: json.data.host,
+						definedPath: json.data.path
 					};
 					this.menu = json.data.options['menu_draft'] || [];
 					this.initialMenu = JSON.stringify(this.menu);
@@ -383,7 +385,7 @@ export default {
 
 		previewSite() {
 			win.open(
-				`${Config.get('base_url', '')}/draft/${this.site.firstPageId}`,
+				`${Config.get('base_url', '')}/draft/${this.site.definedHost}${this.site.definedPath}`,
 				'_blank'
 			);
 		},

--- a/resources/assets/js/views/MenuEditor.vue
+++ b/resources/assets/js/views/MenuEditor.vue
@@ -238,7 +238,6 @@ export default {
 	},
 
 	methods: {
-		// TODO move this outside of component, store current site data in state
 		fetchSiteData() {
 			this.$api
 				.get(`sites/${this.$route.params.site_id}?include=pages`)


### PR DESCRIPTION
Draft preview url is now similar to published page preview url '/draft/{domain-name}/{path-to-page}' instead of '/draft/{id}'.

This makes it simpler to do a string replace on the beginning of URLs to map real published URLs to ones that can be displayed in preview mode.

Added a getter to (page) state to retrieve the preview and published urls for the current page in the editor.

Moved the code that handles draft and published previewing from route file to PageController.

