### PR TITLE
remove trailing slash from root urls for preview and publish as it br…

### DIFF
--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -424,7 +424,7 @@ const getters = {
 	 * @returns {string} Full URL
 	 */
 	draftPreviewURL: (state, getters) => {
-		return `${Config.get('base_url', '')}` + '/draft/' + getters.siteDomain + getters.sitePath + getters.pagePath;
+		return `${Config.get('base_url', '')}` + '/draft/' + getters.siteDomain + getters.sitePath + (getters.pagePath == '/' ? '' : getters.pagePath);
 	},
 
 	/**
@@ -434,7 +434,7 @@ const getters = {
 	 * @returns {string} Full URL
 	 */
 	publishedPreviewURL: (state, getters) => {
-		return `${Config.get('base_url', '')}` + '/published/' + getters.siteDomain + getters.sitePath + getters.pagePath;
+		return `${Config.get('base_url', '')}` + '/published/' + getters.siteDomain + getters.sitePath + (getters.pagePath == '/' ? '' : getters.pagePath);
 	},
 
 	getFieldValue: (state) => (index, name) => {


### PR DESCRIPTION
…eaks on our test server...

webtools-test seems to be redirecting anything on site-editor ending with a / to a 404.

This fix modifies the preview urls for published and draft pages so that if it is the homepage (which is just a /), it does not add the last /.