### PR TITLE
Increase width of 'filter by role' drop down

### DIFF
--- a/resources/assets/sass/views/_site-users.scss
+++ b/resources/assets/sass/views/_site-users.scss
@@ -58,6 +58,6 @@
 	}
 
 	&__select {
-		width: 130px;
+		width: 160px;
 	}
 }


### PR DESCRIPTION
This is to simply increase the width of the 'Filter by role' drop down in the site user management page, so that the 'Filter by role' is visible.