### PR TITLE
Save the page before showing publish dialog

### DIFF
--- a/resources/assets/js/components/Toolbar.vue
+++ b/resources/assets/js/components/Toolbar.vue
@@ -21,7 +21,7 @@
 			class="toolbar__button-publish"
 			v-if="invalidBlocks"
 			type="success"
-			@click="showPublishModal"
+			@click="publishPage"
 		>Publish...</el-button>
 		<el-button
 			class="toolbar__button-publish"
@@ -158,6 +158,14 @@ export default {
 			this.handleSavePage()
 				.then(() => {
 					win.open(this.draftLink,'_blank');
+				});
+		},
+
+		/* save page and then open publish modal */
+		publishPage() {
+			this.handleSavePage()
+				.then(() => {
+					this.showPublishModal();
 				});
 		},
 


### PR DESCRIPTION
Before showing the publish page dialog, save the page first. see https://trello.com/c/ypoxl22o/233-save-and-publish