### PR TITLE
Update API to return published "status" for pages.

### DIFF
--- a/app/Http/Transformers/Api/v1/PageTransformer.php
+++ b/app/Http/Transformers/Api/v1/PageTransformer.php
@@ -57,8 +57,9 @@ class PageTransformer extends FractalTransformer
             'parent_id' => $page->parent_id,
             'site_id' => $page->site_id,
             'revision_id' => $page->revision_id,
-			'valid' => $page->revision->valid
-        ];
+			'valid' => $page->revision->valid,
+			'status' => $page->status
+		];
 		if($this->full){
             $data['blocks'] = $page->revision->blocks;
         }

--- a/app/Http/Transformers/Api/v1/SiteTransformer.php
+++ b/app/Http/Transformers/Api/v1/SiteTransformer.php
@@ -99,6 +99,7 @@ class SiteTransformer extends FractalTransformer
 	public function includeDraftPages(Site $site, ParamBag $params)
 	{
 		$pages = $site->draftPages()
+			->with('published')
 			->orderBy('lft')
 			->get();
 		if($pages){

--- a/app/Http/Transformers/Api/v1/SiteTransformer.php
+++ b/app/Http/Transformers/Api/v1/SiteTransformer.php
@@ -99,7 +99,6 @@ class SiteTransformer extends FractalTransformer
 	public function includeDraftPages(Site $site, ParamBag $params)
 	{
 		$pages = $site->draftPages()
-			->with('published')
 			->orderBy('lft')
 			->get();
 		if($pages){

--- a/app/Models/APICommands/UpdatePageSlug.php
+++ b/app/Models/APICommands/UpdatePageSlug.php
@@ -12,6 +12,7 @@ use App\Models\Page;
 /**
  * Updates the slug for a page.
  * Updates the path for the page and all of its descendants.
+ * Also does this for published version of pages.
  * @package App\Models\APICommands
  */
 class UpdatePageSlug implements APICommand

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -44,8 +44,8 @@ class Page extends BaumNode
 	protected $scoped = ['site_id', 'version'];
 
 	// The draft state of this page.
+	const STATE_NEW = 'new'; // not published
 	const STATE_DRAFT = 'draft'; // modified since last published
-	const STATE_NEW = 'new'; // not yet published
 	const STATE_DELETED = 'deleted'; // deleted since last published
 	const STATE_MOVED = 'moved'; // moved since last published
 	const STATE_PUBLISHED = 'published'; // not modified since last published

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -44,8 +44,8 @@ class Page extends BaumNode
 	protected $scoped = ['site_id', 'version'];
 
 	// The draft state of this page.
-	const STATE_NEW = 'new';  // not published
 	const STATE_DRAFT = 'draft'; // modified since last published
+	const STATE_NEW = 'new'; // not yet published
 	const STATE_DELETED = 'deleted'; // deleted since last published
 	const STATE_MOVED = 'moved'; // moved since last published
 	const STATE_PUBLISHED = 'published'; // not modified since last published
@@ -108,6 +108,26 @@ class Page extends BaumNode
 			}
 		}
 		return $data;
+	}
+
+	/**
+	 * Get the published state of the page.
+	 * @return string One of 'draft', 'modified', 'published'
+	 */
+	public function getStatusAttribute()
+	{
+		$published = $this->publishedVersion();
+		if($published){
+			if($published->revision_id == $this->revision_id){
+				return Page::STATE_PUBLISHED;
+			}
+			else{
+				return Page::STATE_DRAFT;
+			}
+		}
+		else{
+			return Page::STATE_NEW;
+		}
 	}
 
 	/************************************************************************

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -112,13 +112,18 @@ class Page extends BaumNode
 
 	/**
 	 * Get the published state of the page.
-	 * @return string One of 'draft', 'modified', 'published'
+	 * @return string One of 'new', 'draft', 'published'
 	 */
 	public function getStatusAttribute()
 	{
-		$published = $this->publishedVersion();
-		if($published){
-			if($published->revision_id == $this->revision_id){
+		if(Page::STATE_DRAFT == $this->version){
+			$compare_to = $this->publishedVersion();
+		}
+		else {
+			$compare_to = $this->draftVersion();
+		}
+		if($compare_to){
+			if($compare_to->revision_id == $this->revision_id){
 				return Page::STATE_PUBLISHED;
 			}
 			else{
@@ -234,6 +239,20 @@ class Page extends BaumNode
 			return $this;
 		}
 		return Page::published()
+			->forSiteAndPath($this->site_id, $this->path)
+			->first();
+	}
+
+	/**
+	 * Get the draft version of this page.
+	 * @return Page The draft version of this page if it exists (which may be this Page)
+	 */
+	public function draftVersion()
+	{
+		if (Page::STATE_DRAFT == $this->version) {
+			return $this;
+		}
+		return Page::draft()
 			->forSiteAndPath($this->site_id, $this->path)
 			->first();
 	}

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -353,7 +353,7 @@ const getters = {
 	 * @todo - implement once supported by the API.
 	 */
 	publishStatus: (state) =>  {
-		return (state.loaded ? 'new' : '');
+		return (state.loaded ? state.pageData.status : '');
 	},
 
 	/**


### PR DESCRIPTION
Added an attribute getter on Page model to calculate the status of a page based on the state of its published version if one exists.

Currently not eager loaded due to restrictions / lack-of-understanding of eloquent relations.

Used the existing status options as defined in store/page.js and components/TopBar.vue:

- new = Not yet published
- draft = Published but modified
- published = Published and up to date