### PR TITLE
Add page.unpublish permission

### DIFF
--- a/app/Console/Commands/SetupPermissions.php
+++ b/app/Console/Commands/SetupPermissions.php
@@ -46,6 +46,7 @@ class SetupPermissions extends Command
 		Permission::ADD_PAGE => 'Add Pages',
 		Permission::EDIT_PAGE => 'Edit Pages',
 		Permission::DELETE_PAGE => 'Delete Pages',
+		Permission::UNPUBLISH_PAGE => 'Unpublish Pages',
 		Permission::MOVE_PAGE => 'Move Pages',
 		Permission::ADD_IMAGE => 'Add Images',
 		Permission::EDIT_IMAGE => 'Edit Images',
@@ -88,6 +89,7 @@ class SetupPermissions extends Command
 			Permission::EDIT_IMAGE,
 			Permission::USE_IMAGE,
 			Permission::PUBLISH_PAGE,
+			Permission::UNPUBLISH_PAGE,
 			Permission::PREVIEW_PAGE,
 			Permission::APPROVAL,
 			Permission::ASSIGN_SITE_PERMISSIONS,
@@ -109,6 +111,7 @@ class SetupPermissions extends Command
 			Permission::EDIT_IMAGE,
 			Permission::USE_IMAGE,
 			Permission::PUBLISH_PAGE,
+			Permission::UNPUBLISH_PAGE,
 			Permission::PREVIEW_PAGE,
 			Permission::APPROVAL
 		],

--- a/app/Http/Controllers/Api/v1/PageController.php
+++ b/app/Http/Controllers/Api/v1/PageController.php
@@ -149,7 +149,7 @@ class PageController extends ApiController
 	 */
 	public function unpublish(Request $request, Page $page)
 	{
-		$this->authorize('delete', $page);
+		$this->authorize('unpublish', $page);
 		$api = new LocalAPIClient(Auth::user());
 		$result = $api->unpublishPage($page->id);
 		return fractal($result, new PageTransformer(true))->respond();

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -24,6 +24,7 @@ class Permission extends Model
 	const EDIT_IMAGE = 'image.edit';
 	const USE_IMAGE = 'image.use';
 	const PUBLISH_PAGE = 'page.publish';
+	const UNPUBLISH_PAGE = 'page.unpublish';
 	const PREVIEW_PAGE = 'page.preview';
 	const APPROVAL = 'page.approve';
 	const ASSIGN_SITE_PERMISSIONS = 'permissions.site.assign';

--- a/app/Policies/PagePolicy.php
+++ b/app/Policies/PagePolicy.php
@@ -70,6 +70,18 @@ class PagePolicy
         return $user->hasPermissionForSite(Permission::PUBLISH_PAGE, $page->site_id);
     }
 
+	/**
+	 * Determine whether the user can publish the page.
+	 *
+	 * @param  \App\Models\User  $user
+	 * @param  Page  $page
+	 * @return boolean
+	 */
+	public function unpublish(User $user, Page $page)
+	{
+		return $user->hasPermissionForSite(Permission::UNPUBLISH_PAGE, $page->site_id);
+	}
+
     /**
      * Determine whether the user can revert the page.
      *

--- a/database/migrations/2017_11_06_124228_refresh_permissons.php
+++ b/database/migrations/2017_11_06_124228_refresh_permissons.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RefreshPermissons extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Artisan::call('astro:permissions', ['action' => 'refresh']);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 use App\Models\LocalAPIClient;
 use App\Models\User;
+use App\Models\Role;
 use App\Models\Page;
 use Illuminate\Database\Seeder;
 
@@ -79,8 +80,34 @@ class DatabaseSeeder extends Seeder
             'api_token' => 'test'
 		]);
 
+		// create some users to test with...
+		$editor = factory(User::class)->create([
+			'username' => 'editor',
+			'name' => 'Editor',
+			'password' => Hash::make('editor'),
+			'role' => 'user',
+			'api_token' => 'editor-test'
+		]);
 
-        $client = new LocalAPIClient($user);
+		$owner = factory(User::class)->create([
+			'username' => 'owner',
+			'name' => 'Owner',
+			'password' => Hash::make('owner'),
+			'role' => 'user',
+			'api_token' => 'owner-test'
+		]);
+
+		$contributor = factory(User::class)->create([
+			'username' => 'contributor',
+			'name' => 'Contributor',
+			'password' => Hash::make('contributor'),
+			'role' => 'user',
+			'api_token' => 'contributor-test'
+		]);
+
+
+
+		$client = new LocalAPIClient($user);
         $site = $client->createSite(
             'Test Site', 'example.com', '', ['name'=>'kent-homepage','version'=>1]
         );
@@ -92,6 +119,10 @@ class DatabaseSeeder extends Seeder
         $client->publishPage(Page::forSiteAndPath($site->id, '/undergraduate')->first()->id);
         $client->publishPage(Page::forSiteAndPath($site->id, '/undergraduate/2017')->first()->id);
         $client->publishPage(Page::forSiteAndPath($site->id, '/undergraduate/2018')->first()->id);
+
+		$client->updateSiteUserRole($site->id,'editor', Role::EDITOR);
+		$client->updateSiteUserRole($site->id,'owner', Role::OWNER);
+		$client->updateSiteUserRole($site->id,'contributor', Role::CONTRIBUTOR);
     }
 
 	/**

--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -70,7 +70,7 @@
 
 				<el-dropdown-item
 					command="unpublish"
-					v-if="canUser('page.delete')"
+					v-if="canUser('page.unpublish')"
 					:disabled="page.status === 'new'"
 				>
 					Unpublish


### PR DESCRIPTION
Adds a new permission "page.unpublish" and assigns it to owners and editors.

API requires this permission to unpublish a page, editor doesn't display unpublish option if this permission is not present.

Added a migration that runs the "astro:permissions refresh" command as I kept on forgetting to do this after refreshing my database.

Added creation of 3 accounts, 'editor', 'owner' and 'contributor' (same values for password) during the database seeding, assigning each to a role matching their username on the default created site to simplify testing.
