### PR TITLE
Fix Draft and Published Preview URL links

### DIFF
--- a/resources/assets/js/classes/helpers.js
+++ b/resources/assets/js/classes/helpers.js
@@ -168,3 +168,22 @@ export const notify = ({ title, message, type }) => {
 export const pageHasBeenPublished = (page) => {
 	return page.status !== 'new';
 };
+
+
+/**
+ * Get the URL at which the current page can be previewed in the editor.
+ * @param {string} url - The page URL to mutate into a draft preview URL
+ * @returns {string} Full URL
+ */
+export const getDraftPreviewURL = (url) => {
+	return `${Config.get('base_url', '')}` + '/draft/' + url;
+};
+
+/**
+ * Get the URL at which the published version of the current page can be previewed in the editor.
+ * @param {string} url - The page URL to mutate into a published preview URL.
+ * @returns {string} Full URL
+ */
+export const getPublishedPreviewURL = (url) => {
+	return `${Config.get('base_url', '')}` + '/published/' + url;
+};

--- a/resources/assets/js/components/PublishModal.vue
+++ b/resources/assets/js/components/PublishModal.vue
@@ -46,7 +46,7 @@ An element loading spinner is shown after the user hits 'Publish'.
 			:closable=false
 			>
 		</el-alert>
-		<div class="publish-modal__message">View your new page now at <a :href="renderedURL" target="_blank">{{ renderedURL }}</a> (opens in a new tab)</div>
+		<div class="publish-modal__message">View your new page now at <a :href="previewURL" target="_blank">{{ renderedURL }}</a> (opens in a new tab)</div>
 		<div class="publish-modal__buttons">
 			<span slot="footer" class="dialog-footer">
 				<el-button type="primary" @click="hidePublishModal">Close</el-button>
@@ -82,6 +82,7 @@ An element loading spinner is shown after the user hits 'Publish'.
 
 <script>
 import { mapState, mapMutations, mapGetters, mapActions } from 'vuex';
+import { getPublishedPreviewURL } from 'classes/helpers';
 
 export default {
 	name: 'publish-modal',
@@ -134,6 +135,10 @@ export default {
 					this.hidePublishModal();
 				}
 			}
+		},
+
+		previewURL() {
+			return getPublishedPreviewURL(this.renderedURL);
 		},
 
 		// frontend URL - so the user can view the page's url

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -37,12 +37,12 @@ TODO: Add last published date after the page status
 					{{ pageTitle }}
 					<el-tag type="warning">Draft</el-tag>
 				</div>
-				<span class="top-bar__url"><a :href="renderedURL" target="_blank">{{ renderedURL }}</a> <icon name="newwindow" aria-hidden="true" width="12" height="12" class="ico" /></span>
+				<span class="top-bar__url"><a :href="draftPreviewURL" target="_blank">{{ renderedURL }}</a> <icon name="newwindow" aria-hidden="true" width="12" height="12" class="ico" /></span>
 			</div>
 
 			<div v-else-if="showTools && publishStatus === 'published'" class="top-bar__page-title">
 				<div class="top-bar__title">{{ pageTitle }}<el-tag type="success">Published</el-tag></div>
-				<span class="top-bar__url"><a :href="renderedURL" target="_blank">{{ renderedURL }}</a> <icon name="newwindow" aria-hidden="true" width="12" height="12" class="ico" /></span>
+				<span class="top-bar__url"><a :href="publishedPreviewURL" target="_blank">{{ renderedURL }}</a> <icon name="newwindow" aria-hidden="true" width="12" height="12" class="ico" /></span>
 			</div>
 
 			<div v-else-if="showTools" class="top-bar__page-title">
@@ -104,7 +104,9 @@ TODO: Add last published date after the page status
 				'pageSlug',
 				'pagePath',
 				'sitePath',
-				'siteDomain'
+				'siteDomain',
+				'publishedPreviewURL',
+				'draftPreviewURL'
 			]),
 
 			// works out if we should show a back button or not (ie whether we're editing a page or on the homepage)

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -381,6 +381,10 @@ const actions = {
 
 const getters = {
 
+	/**
+     * Get a Page referenced by either its id or array path ( eg. 0.3.1 )
+	 * @param state
+	 */
 	getPage: (state) => ({ arrayPath, id }) => {
 		if(arrayPath === null || id === null) {
 			return null;
@@ -388,7 +392,6 @@ const getters = {
 		else if(arrayPath) {
 			return getPage(state.pages, arrayPath);
 		}
-
 		return findPageById(state.pages, id);
 	}
 };
@@ -402,8 +405,14 @@ const
 		}
 	},
 
-	getPage = (page, fullPath) => {
-		const path = Array.isArray(fullPath) ? fullPath : fullPath.split('.');
+	/**
+	 * Get the Page matching the specified array path.(e.g. 0.3.1)
+	 * @param {Array} page - Array of Pages.
+	 * @param {string|Array} arrayPath - Path representing the page in the hierarchy or children arrays, eg. 0.3.2 for
+	 * page[0].children[3].children[2]
+	 */
+	getPage = (page, arrayPath) => {
+		const path = Array.isArray(arrayPath) ? arrayPath : arrayPath.split('.');
 
 		for(var i = 0, length = path.length; page !== void 0 && i < length; i++) {
 			page = i > 0 ? page.children[path[i]] : page[path[i]];


### PR DESCRIPTION
Added a couple of helpers to ensure clickable links for previewing the draft and published versions
of pages are correct.