### PR TITLE
Fix/prompt to save being too prompty

### DIFF
--- a/resources/assets/js/views/Editor.vue
+++ b/resources/assets/js/views/Editor.vue
@@ -84,7 +84,7 @@ export default {
 	},
 
 	destroyed() {
-		// we have left the page editor so we no longer can have unsaved changes
+		// we have left the page editor so remove the snapeshot of the latest saved content
 		this.$store.commit('resetCurrentSavedState');
 	},
 
@@ -97,13 +97,9 @@ export default {
 				customClass: 'loading-overlay'
 			});
 		},
-
-		updateCurrentSavedState() {
-			this.$store.commit('updateCurrentSavedState');
-		}
 	},
 	computed: {
-
+		
 		...mapState([
 			'displayIframeOverlay',
 			'currentView'
@@ -134,7 +130,8 @@ export default {
 
 	watch: {
 		pageLoaded(hideLoader) {
-			this.updateCurrentSavedState();
+			// update/set the current snapshot of the saved page content
+			this.$store.commit('updateCurrentSavedState');
 			if(hideLoader) {
 				if(this.loader) {
 					this.loader.close();

--- a/resources/assets/js/views/Editor.vue
+++ b/resources/assets/js/views/Editor.vue
@@ -83,6 +83,11 @@ export default {
 		};
 	},
 
+	destroyed() {
+		// we have left the page editor so we no longer can have unsaved changes
+		this.$store.commit('resetCurrentSavedState');
+	},
+
 	methods: {
 
 		showLoader() {


### PR DESCRIPTION
This fix stops Astro prompting you to save unsaved changes when leaving the site, manage users screen or menu editor screen. 

Fix for https://trello.com/c/xhiZSfIR

Background: 
When the user saves / loads content for a page within the editor then a json string of all the block data is held within the vuex state. When the user attempts to close the page or leave the page editing part of astro then that json string is compared with the current block data, if they are different then the user is prompted to save changes. 

The bug was that when the user left the page editing section of astro that json string of block data was left in the state and so when the user went to leave the site or click the 'sites' link then the editor mistakenly prompted the user to save.

Fix was to clear that json string when the editor.vue component (which surrounds the page editing part of astro) was destroyed. 
