### PR TITLE
Require version number when referencing definitions.

### DIFF
--- a/app/Models/APICommands/UpdateContent.php
+++ b/app/Models/APICommands/UpdateContent.php
@@ -109,7 +109,12 @@ class UpdateContent implements APICommand
 	{
 		$rules = [];
 		// ...load the Block definition...
-		$file = BlockDefinition::locateDefinition($block['definition_name'] . '-v' . $block['definition_version']);
+		$file = BlockDefinition::locateDefinition(
+			BlockDefinition::idFromNameAndVersion(
+				$block['definition_name'],
+				$block['definition_version']
+			)
+		);
 		$blockDefinition = BlockDefinition::fromDefinitionFile($file);
 
 		// ...load the validation rules from the definition...

--- a/app/Models/APICommands/UpdateContent.php
+++ b/app/Models/APICommands/UpdateContent.php
@@ -192,9 +192,11 @@ class UpdateContent implements APICommand
 						// ...merge any region constraint validation rules...
 						$allowedBlocksRules = $sectionConstraintRules['allowedBlocks'];
 
-						foreach ($allowedBlocksRules as $field => $ruleset) {
-							$key = sprintf('blocks.%s.%d.blocks.%d.%s', $region_id, $section_delta, $block_delta, $field);
-							$rules[$key] = ('definition_name' == $field ? str_replace('{version}', $block['definition_version'], $ruleset) : $ruleset);
+						foreach ($allowedBlocksRules as $attribute => $ruleset) {
+							$key = sprintf('blocks.%s.%d.blocks.%d.%s', $region_id, $section_delta, $block_delta, $attribute);
+							// if the rule is the inVersioned one comparing {definition_name}-v{definition_version}
+							// with the list of allowedBlocks, then inject this block's version number into the rule.
+							$rules[$key] = ('definition_name' == $attribute ? str_replace('{version}', $block['definition_version'], $ruleset) : $ruleset);
 						}					
 					}
 				}

--- a/app/Models/APICommands/UpdateContent.php
+++ b/app/Models/APICommands/UpdateContent.php
@@ -108,8 +108,7 @@ class UpdateContent implements APICommand
 	{
 		$rules = [];
 		// ...load the Block definition...
-		$version = isset($block['definition_version']) ? $block['definition_version'] : null;
-		$file = BlockDefinition::locateDefinition($block['definition_name'], $version);
+		$file = BlockDefinition::locateDefinition($block['definition_name'] . '-v' . $block['definition_version']);
 		$blockDefinition = BlockDefinition::fromDefinitionFile($file);
 
 		// ...load the validation rules from the definition...
@@ -158,8 +157,7 @@ class UpdateContent implements APICommand
 		if ($data->has('blocks') && is_array($data->get('blocks'))) {
 			foreach ($data->get('blocks', []) as $region_id => $sections) {
 				// ...load the Region definition...
-				$parts = Region::idToNameAndVersion($region_id);
-				$file = RegionDefinition::locateDefinition($parts['name'],$parts['version']);
+				$file = RegionDefinition::locateDefinition($region_id);
 				$regionDefinition = RegionDefinition::fromDefinitionFile($file);
 				$rb = new RegionBroker($regionDefinition);
 

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -45,7 +45,7 @@ class Block extends Model
 	 */
 	public function loadDefinition()
 	{
-		$file = BlockDefinition::locateDefinition($this->definition_name, $this->definition_version);
+		$file = BlockDefinition::locateDefinition(BlockDefinition::idFromNameAndVersion($this->definition_name, $this->definition_version));
 		$definition = BlockDefinition::fromDefinitionFile($file);
 
 		$this->definition = $definition;

--- a/app/Models/Definitions/BaseDefinition.php
+++ b/app/Models/Definitions/BaseDefinition.php
@@ -25,6 +25,21 @@ abstract class BaseDefinition implements Arrayable, DefinitionContract, Jsonable
 
     protected static $defDir = '';
 
+	/**
+	 * Extract the name and version number from a definition identifier
+	 * @param string $id - Definition identifier in the form {name}-v{version}
+	 * @return array|null [ 'name' => {name}, 'version' => {version} ] or null if no match.
+	 */
+    public static function idToNameAndVersion($id)
+	{
+		if(preg_match('/^(.+)-v([0-9]+)$/', $id, $matches)){
+			return [
+				'name' => $matches[1],
+				'version' => $matches[2]
+			];
+		}
+		return null;
+	}
 
     /**
      * Dynamically retrieve attributes on the model.

--- a/app/Models/Definitions/BaseDefinition.php
+++ b/app/Models/Definitions/BaseDefinition.php
@@ -27,7 +27,9 @@ abstract class BaseDefinition implements Arrayable, DefinitionContract, Jsonable
 
 	/**
 	 * Extract the name and version number from a definition identifier
+
 	 * @param string $id - Definition identifier in the form {name}-v{version}
+
 	 * @return array|null [ 'name' => {name}, 'version' => {version} ] or null if no match.
 	 */
     public static function idToNameAndVersion($id)
@@ -39,6 +41,19 @@ abstract class BaseDefinition implements Arrayable, DefinitionContract, Jsonable
 			];
 		}
 		return null;
+	}
+
+	/**
+	 * Get a version identifier string based on its name and version.
+
+	 * @param string $name - The definition name.
+	 * @param integer $version - The definition version.
+
+	 * @return string {name}-v{version}
+	 */
+	public static function idFromNameAndVersion($name, $version)
+	{
+		return $name . '-v' . $version;
 	}
 
     /**
@@ -336,34 +351,30 @@ abstract class BaseDefinition implements Arrayable, DefinitionContract, Jsonable
      * Locates a Definition file on disk; when no version is specified
      * it will return the latest.
      *
-     * @param  string $name
-     * @param  int $version
+	 * @param  string $definition_id - The {name}-v{version} string identifying the definition.
      * @return string|null
      */
-    public static function locateDefinition($name, $version = null){
-        if(is_null($version)){
-            $path = sprintf('%s/%s/%s/*', Config::get('app.definitions_path'), static::$defDir, $name);
-            $glob = glob($path, GLOB_ONLYDIR);
-            $path = array_pop($glob);
-        } else {
-            $path = sprintf('%s/%s/%s/v%d', Config::get('app.definitions_path'), static::$defDir, $name, $version);
-        }
-
-        $path .= '/definition.json';
-        return file_exists($path) ? $path : null;
+    public static function locateDefinition($definition_id){
+    	$parts = static::idToNameAndVersion($definition_id);
+    	if($parts) {
+			$path = sprintf('%s/%s/%s/v%d', Config::get('app.definitions_path'), static::$defDir, $parts['name'], $parts['version']);
+			$path .= '/definition.json';
+			return file_exists($path) ? $path : null;
+		}
+		return null;
     }
 
 
     /**
      * Locates a Definition file on disk; throws an exception if no Definition is found.
      *
-     * @param  string $name
+     * @param  string $definition_id - The {name}-v{version} string identifying the definition.
      * @param  int $version
      * @throws App\Exceptions\DefinitionNotFoundException
      * @return string
      */
-    public static function locateDefinitionOrFail($name, $version = null){
-        $path = static::locateDefinition($name, $version);
+    public static function locateDefinitionOrFail($definition_id){
+        $path = static::locateDefinition($definition_id);
         if(is_null($path)) throw new DefinitionNotFoundException;
 
         return $path;

--- a/app/Models/Definitions/Contracts/Definition.php
+++ b/app/Models/Definitions/Contracts/Definition.php
@@ -48,11 +48,10 @@ interface Definition {
      * Locates a Definition file on disk; when no version is specified
      * it will return the latest.
      *
-     * @param  string $name
-     * @param  int $version
+	 * @param  string $definition_id - The {name}-v{version} string identifying the definition.
      * @return string|null
      */
-    public static function locateDefinition($name, $version = null);
+    public static function locateDefinition($definition_id);
 
     /**
      * Locates a Definition file on disk; throws an exception if no Definition is found.
@@ -62,6 +61,6 @@ interface Definition {
      * @throws App\Exceptions\DefinitionNotFoundException
      * @return string
      */
-    public static function locateDefinitionOrFail($name, $version = null);
+    public static function locateDefinitionOrFail($definition_id);
 
 }

--- a/app/Models/Definitions/Layout.php
+++ b/app/Models/Definitions/Layout.php
@@ -25,8 +25,7 @@ class Layout extends BaseDefinition
 	 */
 	public function loadRegionDefinitions(){
 		foreach($this->regions as $region_id){
-			$parts = static::idToNameAndVersion($region_id);
-			$path = Region::locateDefinition($parts['name'],$parts['version']);
+			$path = Region::locateDefinition($region_id);
 			if(!is_null($path)){
 				$region = Region::fromDefinitionFile($path);
 				$this->regionDefinitions->push($region);
@@ -42,7 +41,7 @@ class Layout extends BaseDefinition
 	{
 		$regions = [];
 		foreach($this->getRegionDefinitions() as $region_definition) {
-			$regions[$region_definition->name . '-v' . $region_definition->version] = $region_definition->getDefaultBlocks();
+			$regions[Region::idFromNameAndVersion($region_definition->name, $region_definition->version)] = $region_definition->getDefaultBlocks();
 		}
 		return $regions;
 	}

--- a/app/Models/Definitions/Layout.php
+++ b/app/Models/Definitions/Layout.php
@@ -24,9 +24,9 @@ class Layout extends BaseDefinition
 	 * @return void
 	 */
 	public function loadRegionDefinitions(){
-		foreach($this->regions as $name){
-			$path = Region::locateDefinition($name);
-
+		foreach($this->regions as $region_id){
+			$parts = static::idToNameAndVersion($region_id);
+			$path = Region::locateDefinition($parts['name'],$parts['version']);
 			if(!is_null($path)){
 				$region = Region::fromDefinitionFile($path);
 				$this->regionDefinitions->push($region);
@@ -42,7 +42,7 @@ class Layout extends BaseDefinition
 	{
 		$regions = [];
 		foreach($this->getRegionDefinitions() as $region_definition) {
-			$regions[$region_definition->name] = $region_definition->getDefaultBlocks();
+			$regions[$region_definition->name . '-v' . $region_definition->version] = $region_definition->getDefaultBlocks();
 		}
 		return $regions;
 	}

--- a/app/Models/Definitions/Region.php
+++ b/app/Models/Definitions/Region.php
@@ -26,8 +26,9 @@ class Region extends BaseDefinition
 	 */
 	public function loadBlockDefinitions(){
 		foreach($this->sections as $section){
-			foreach( $section['allowedBlocks'] as $name) {
-				$path = Block::locateDefinition($name);
+			foreach( $section['allowedBlocks'] as $block_id ) {
+				$parts = static::idToNameAndVersion($block_id);
+				$path = Block::locateDefinition( $parts['name'], $parts['version']);
 
 				if (!is_null($path)) {
 					$block = Block::fromDefinitionFile($path);
@@ -61,7 +62,9 @@ class Region extends BaseDefinition
 			$section = [ 'name' => $section_def['name'], 'blocks' => []];
 			if($section_def['defaultBlocks']){
 				foreach($section_def['defaultBlocks'] as $block_id){
-					$block_def = Block::fromDefinitionFile(Block::locateDefinition($block_id));
+					$parts = static::idToNameAndVersion($block_id);
+
+					$block_def = Block::fromDefinitionFile(Block::locateDefinition($parts['name'],$parts['version']));
 					if($block_def){
 						$section['blocks'][] = $block_def->getDefaultData($this->name, $section_def['name']);
 					}

--- a/app/Models/Definitions/Region.php
+++ b/app/Models/Definitions/Region.php
@@ -27,8 +27,7 @@ class Region extends BaseDefinition
 	public function loadBlockDefinitions(){
 		foreach($this->sections as $section){
 			foreach( $section['allowedBlocks'] as $block_id ) {
-				$parts = static::idToNameAndVersion($block_id);
-				$path = Block::locateDefinition( $parts['name'], $parts['version']);
+				$path = Block::locateDefinition( $block_id);
 
 				if (!is_null($path)) {
 					$block = Block::fromDefinitionFile($path);
@@ -62,9 +61,7 @@ class Region extends BaseDefinition
 			$section = [ 'name' => $section_def['name'], 'blocks' => []];
 			if($section_def['defaultBlocks']){
 				foreach($section_def['defaultBlocks'] as $block_id){
-					$parts = static::idToNameAndVersion($block_id);
-
-					$block_def = Block::fromDefinitionFile(Block::locateDefinition($parts['name'],$parts['version']));
+					$block_def = Block::fromDefinitionFile(Block::locateDefinition($block_id));
 					if($block_def){
 						$section['blocks'][] = $block_def->getDefaultData($this->name, $section_def['name']);
 					}

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -94,11 +94,12 @@ class Page extends BaumNode
 			->get()
 			->groupBy('region_name');
 		$this->load('blocks.media');
-		foreach ($blocksByRegion as $region => $blocks) {
+		foreach ($blocksByRegion as $region_id => $blocks) {
 			// need the region definition to get sections in the correct order
-			$regionDef = Region::fromDefinitionFile(Region::locateDefinition($region));
+			$parts = Region::idToNameAndVersion($region_id);
+			$regionDef = Region::fromDefinitionFile(Region::locateDefinition($parts['name'], $parts['version']));
 			$sections = $blocks->groupBy('section_name');
-			$data[$region] = [];
+			$data[$region_id] = [];
 			foreach($regionDef->sections as $section_def){
 				$section = ['name' => $section_def['name'], 'blocks' => []];
 				if(!empty($sections[$section_def['name']])){
@@ -115,7 +116,7 @@ class Page extends BaumNode
 						];
 					}
 				}
-				$data[$region][] = $section;
+				$data[$region_id][] = $section;
 			}
 		}
 		return $data;

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -96,8 +96,7 @@ class Page extends BaumNode
 		$this->load('blocks.media');
 		foreach ($blocksByRegion as $region_id => $blocks) {
 			// need the region definition to get sections in the correct order
-			$parts = Region::idToNameAndVersion($region_id);
-			$regionDef = Region::fromDefinitionFile(Region::locateDefinition($parts['name'], $parts['version']));
+			$regionDef = Region::fromDefinitionFile(Region::locateDefinition($region_id));
 			$sections = $blocks->groupBy('section_name');
 			$data[$region_id] = [];
 			foreach($regionDef->sections as $section_def){
@@ -437,7 +436,7 @@ class Page extends BaumNode
 	 */
 	public function createDefaultBlocks($layout_name, $layout_version)
 	{
-		$layout_definition = Layout::fromDefinitionFile(Layout::locateDefinition($layout_name,$layout_version));
+		$layout_definition = Layout::fromDefinitionFile(Layout::locateDefinition(Layout::idFromNameAndVersion($layout_name, $layout_version)));
 		if($layout_definition){
 			$data = $layout_definition->getDefaultPageContent();
 			$this->saveBlocks($this->id, $data);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\APICommands\PublishPage;
+use App\Models\Definitions\BaseDefinition;
 use App\Models\Page;
 use App\Validation\Rules\LayoutExistsRule;
 use App\Validation\Rules\UniqueSitePathRule;
@@ -96,7 +97,7 @@ class AppServiceProvider extends ServiceProvider
 			$version = (isset($parameters[1]) && isset($data[$parameters[1]])) ? $data[$parameters[1]] : null;
 
 			$class = $parameters[0];
-			return $class::locateDefinition($name, $version) ? true : false;
+			return $class::locateDefinition(BaseDefinition::idFromNameAndVersion($name,$version)) ? true : false;
 		});
 
 		/**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -99,7 +99,7 @@ class AppServiceProvider extends ServiceProvider
 			$version = (isset($parameters[1]) && isset($data[$parameters[1]])) ? $data[$parameters[1]] : null;
 
 			$class = $parameters[0];
-			return $class::locateDefinition(BaseDefinition::idFromNameAndVersion($name,$version)) ? true : false;
+			return $class::locateDefinition($class::idFromNameAndVersion($name,$version)) ? true : false;
 		});
 
 		/**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,7 +32,9 @@ class AppServiceProvider extends ServiceProvider
 		 */
 		Validator::extend('inVersioned', function($attr, $value, $parameters){
 			$id = $value . '-v' . $parameters[0];
-			return in_array($id, explode(',',$parameters[1]));
+			array_shift($parameters);
+			$options = join(',',$parameters);
+			return in_array($id, explode(',',$options));
 		});
 
 		Validator::extend('slug_unchanged_or_unique', function($attr, $value, $parameters, $validator) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -24,6 +24,16 @@ class AppServiceProvider extends ServiceProvider
 	{
 		Schema::defaultStringLength(191); // Fix for the webfarm running older MySQL
 
+		/**
+		 * Hack to be able to validate a block's combined name and version are in the {name}-v{version}s listed
+		 * in the allowedBlocks array of section definitions.
+		 * TODO refactor so that block's have a definition_id or type instead of name and version?
+		 */
+		Validator::extend('inVersioned', function($attr, $value, $parameters){
+			$id = $value . '-v' . $parameters[0];
+			return in_array($id, explode(',',$parameters[1]));
+		});
+
 		Validator::extend('slug_unchanged_or_unique', function($attr, $value, $parameters, $validator) {
 			$id = isset($parameters[0]) ? $parameters[0] : null;
 			$page = Page::find($id);

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -41,17 +41,17 @@ class RouteServiceProvider extends ServiceProvider
 		});
 
 		Route::bind('block_definition', function ($value) {
-			$path = BlockDefinition::locateDefinitionOrFail($value, request()->get('version', null));
+			$path = BlockDefinition::locateDefinitionOrFail($value);
 			return BlockDefinition::fromDefinitionFile($path);
 		});
 
 		Route::bind('layout_definition', function ($value) {
-			$path = LayoutDefinition::locateDefinitionOrFail($value, request()->get('version', null));
+			$path = LayoutDefinition::locateDefinitionOrFail($value);
 			return LayoutDefinition::fromDefinitionFile($path);
 		});
 
 		Route::bind('region_definition', function ($value) {
-			$path = RegionDefinition::locateDefinitionOrFail($value, request()->get('version', null));
+			$path = RegionDefinition::locateDefinitionOrFail($value);
 			return RegionDefinition::fromDefinitionFile($path);
 		});
 	}

--- a/app/Validation/Brokers/RegionBroker.php
+++ b/app/Validation/Brokers/RegionBroker.php
@@ -41,7 +41,7 @@ class RegionBroker extends DefinitionBroker
 				if (isset($section_definition['allowedBlocks'])) {
 					$rules['allowedBlocks'] = [
 						'definition_name' => [
-							'in:' . implode(',', $section_definition['allowedBlocks']),
+							'inVersioned:{version},' . implode(',', $section_definition['allowedBlocks']),
 						]
 					];
 				}

--- a/app/Validation/Rules/LayoutExistsRule.php
+++ b/app/Validation/Rules/LayoutExistsRule.php
@@ -28,7 +28,7 @@ class LayoutExistsRule
     */
     public function passes($attribute, $value)
     {
-        return Layout::locateDefinition($value, $this->version) != false;
+        return Layout::locateDefinition($value . '-v' . $this->version) != false;
     }
 
     /**

--- a/app/Validation/Rules/LayoutExistsRule.php
+++ b/app/Validation/Rules/LayoutExistsRule.php
@@ -28,7 +28,9 @@ class LayoutExistsRule
     */
     public function passes($attribute, $value)
     {
-        return Layout::locateDefinition($value . '-v' . $this->version) != false;
+        return Layout::locateDefinition(
+            Layout::idFromNameAndVersion($value, $this->version)
+        ) != false;
     }
 
     /**

--- a/database/migrations/2017_11_27_123147_migrate_data_to_include_versions_in_definitions.php
+++ b/database/migrations/2017_11_27_123147_migrate_data_to_include_versions_in_definitions.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\Revision;
+use App\Models\Block;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Migrates any block definitions not using the {name}-v{version} format for identifying regions.
+ */
+class MigrateDataToIncludeVersionsInDefinitions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+	{
+		$count = $updated = 0;
+		foreach (Revision::all() as $revision) {
+			$json = $revision->blocks;
+			$count++;
+			if (!empty($json)) {
+				$data = [];
+				$changed = false;
+				foreach ($json as $name => $sections) {
+					if (!preg_match('/-v[0-9]+$/', $name)) {
+						$name = $name . '-v1';
+						$changed = true;
+					}
+					$data[$name] = $sections;
+				}
+				if($changed) {
+					$revision->blocks = $data;
+					$revision->save();
+					$updated++;
+				}
+			}
+		}
+		echo "$updated of $count revisions updated to use {name}-v{version} syntax for identifying regions.\n";
+		$updated = $count = 0;
+		foreach (Block::all() as $block) {
+			$count++;
+			if (!preg_match('/-v[0-9]+$/', $block->region_name)) {
+				$updated++;
+				$block->region_name .= '-v1';
+				$block->save();
+			}
+		}
+		echo "$updated of $count blocks updated to use {name}-v{version} syntax for identifying regions.\n";
+	}
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/resources/assets/js/classes/Definition.js
+++ b/resources/assets/js/classes/Definition.js
@@ -35,23 +35,22 @@ export default class Definition {
 
 	/**
 	 * Add a region definition indexed by name
-	 * @param {string} name
 	 * @param {Object} regionDefinition - The Region definition to add.
 	 */
 	static addRegionDefinition(regionDefinition) {
-		Definition.regionDefinitions[regionDefinition.name] = regionDefinition;
+		Definition.regionDefinitions[Definition.getType(regionDefinition)] = regionDefinition;
 	}
 
 	/**
 	 * Get a section definition by region name and index.
-	 * @param {string} regionName - The name of the region containing the section.
+	 * @param {string} regionID - The name and version (type) of the region containing the section.
 	 * @param {number} sectionIndex - The index of the section in the region.
 	 * @returns {null|Object} - Section definition if found, otherwise null.
 	 */
-	static getRegionSectionDefinition(regionName, sectionIndex) {
-		if(Definition.regionDefinitions[regionName] !== void 0){
-			if(sectionIndex < Definition.regionDefinitions[regionName].sections.length){
-				return Definition.regionDefinitions[regionName].sections[sectionIndex];
+	static getRegionSectionDefinition(regionID, sectionIndex) {
+		if(Definition.regionDefinitions[regionID] !== void 0){
+			if(sectionIndex < Definition.regionDefinitions[regionID].sections.length){
+				return Definition.regionDefinitions[regionID].sections[sectionIndex];
 			}
 		}
 		return null;

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -16,9 +16,6 @@
 					:value="item.name">
 			</el-option>
 		</el-select>
-		<el-form-item label="Layout Version">
-			<el-input name="layout_version" v-model="createForm.layout_version" auto-complete="off"></el-input>
-		</el-form-item>
 		<el-form-item label="slug">
 			<el-input 
 				name="slug"
@@ -48,21 +45,20 @@ export default {
 			layouts: [
 				{
 					label: 'Kent homepage',
-					name: 'kent-homepage'
+					name: 'kent-homepage-v1'
 				},
 				{
 					label: 'Site homepage',
-					name: 'site-homepage'
+					name: 'site-homepage-v1'
 				},
 				{
 					label: 'Content page',
-					name: 'content'
+					name: 'content-v1'
 				}
 			],
 			createForm: {
 				title: 'New page',
-				layout_name: 'site-homepage',
-				layout_version: 1,
+				layout_name: 'site-homepage-v1',
 				route: {
 					slug: '',
 					parent_id: 1
@@ -120,7 +116,7 @@ export default {
 		},
 
 		setUserEditingSlug() {
-			if (this.userEditingSlug ==  false) {
+			if (this.userEditingSlug ===  false) {
 				this.userEditingSlug = true;
 				this.createForm.route.slug = this.suggestedSlug;
 			}
@@ -129,8 +125,7 @@ export default {
 		resetForm() {
 			this.createForm = {
 				title: 'New page',
-				layout_name: 'site-homepage',
-				layout_version: 1,
+				layout_name: 'site-homepage-v1',
 				route: {
 					slug: '',
 					parent_id: 1
@@ -138,21 +133,6 @@ export default {
 				blocks: {},
 				options: {}
 			}
-		},
-
-		saveEdit() {
-			// TODO: when endpoint is ready, update this
-			// this.updatePage({
-			// 	title: this.currentPage.title,
-			// 	id: this.currentPage.id,
-			// 	page_id: this.currentPage.page_id,
-			// 	layout_name: this.layout_name,
-			// 	layout_version: this.layout_version,
-			// 	route: {
-			// 		slug: this.currentPage.slug,
-			// 		parent_id: this.currentPage.parent_id
-			// 	}
-			// });
 		},
 
 		getLayout(layoutName) {

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -54,6 +54,14 @@ export default {
 				{
 					label: 'Content page',
 					name: 'content-v1'
+				},
+				{
+					label: 'School homepage',
+					name: 'school-homepage-v1'
+				},
+				{
+					label: 'School about us',
+					name: 'school-about-v1'
 				}
 			],
 			createForm: {

--- a/resources/assets/js/components/Region.vue
+++ b/resources/assets/js/components/Region.vue
@@ -3,7 +3,7 @@
 	<template v-if="sections">
 		<region-section
 			v-for="(sectionData, index) in sections"
-			:region="name"
+			:region="regionID"
 			:section="index"
 			:key="`section-${sectionData.name}`"
 			:index="index"
@@ -29,7 +29,7 @@ export default {
 			type: String,
 			required: true
 		},
-		version: { 	// The version of this region's definition (not currently used?)
+		version: { 	// The version of this region's definition
 			type: String,
 			required: false
 		}
@@ -40,8 +40,11 @@ export default {
 	},
 
 	computed: {
+		regionID() {
+			return this.name + '-v' + this.version;
+		},
 		sections() {
-			return this.$store.getters.getRegionSections(this.name);
+			return this.$store.getters.getRegionSections(this.name + '-v' + this.version);
 		}
 	},
 };

--- a/resources/assets/js/mixins/baseFieldMixin.js
+++ b/resources/assets/js/mixins/baseFieldMixin.js
@@ -14,7 +14,7 @@ export default {
 		]),
 		...mapState({
 			currentBlockIndex: state => state.contenteditor.currentBlockIndex,
-			currentRegionName: state => state.contenteditor.currentRegionName
+			currentRegionName: state => state.contenteditor.currentRegionName,
 		}),
 
 		value: {

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -259,7 +259,7 @@ const actions = {
 				const page = response.data.data;
 
 				api
-					.get(`layouts/${page.layout.name}/definition?include=region_definitions.block_definitions`)
+					.get(`layouts/${page.layout.name}-v${page.layout.version}/definition?include=region_definitions.block_definitions`)
 					.then(({ data: region }) => {
 
 						region.data.region_definitions.forEach((region, regionName) => {

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -220,8 +220,8 @@ const actions = {
 				parent_id: page.route.parent_id,
 				slug: page.route.slug,
 				layout: {
-					name: page.layout_name,
-					version: page.layout_version,
+					name: page.layout_name.replace(/-v[0-9]+$/, ''),
+					version: page.layout_name.replace(/^.+?-v([0-9]+)$/, '$1'),
 				},
 				title: page.title
 			})

--- a/resources/assets/js/test/schemas/layout.spec.json
+++ b/resources/assets/js/test/schemas/layout.spec.json
@@ -5,7 +5,13 @@
 		"name": { "type": "string" },
 		"label": { "type": "string" },
 		"version": { "type": "integer", "default": 1 },
-		"regions": { "type": "array", "items": { "type": "string" } }
+		"regions": { "type": "array", "items": { "$ref": "#/definitions/regionName" } }
 	},
-	"required": ["name", "label", "version", "regions"]
+	"required": ["name", "label", "version", "regions"],
+	"definitions": {
+		"regionName": {
+			"type": "string",
+			"pattern": "^[a-z]+(?:-+[a-z]+)*-v\\d+$"
+		}
+	}
 }

--- a/resources/assets/js/test/unit/SectionConstraints.spec.js
+++ b/resources/assets/js/test/unit/SectionConstraints.spec.js
@@ -17,6 +17,7 @@ describe('Region section Constraints', () => {
 			const constraint = allowedOperations();
 
 			expect(constraint).to.deep.equal({
+				allowedBlocks: null,
 				canAddBlocks: true,
 				canRemoveBlocks: true,
 				canSwapBlocks: false

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -180,7 +180,6 @@ export default {
 		...mapMutations([
 			'reorderBlocks',
 			'deleteBlock',
-			'updateBlockMeta',
 			'setScale',
 			'showBlockPicker',
 			'updateInsertIndex',

--- a/tests/Support/Fixtures/api_requests/v1/update_content.json
+++ b/tests/Support/Fixtures/api_requests/v1/update_content.json
@@ -1,6 +1,6 @@
 {
 	"blocks": {
-		"test-region": [
+		"test-region-v1": [
 			{
 				"name": "test-section",
 				"blocks": [

--- a/tests/Support/Fixtures/definitions/layouts/test-layout/v1/definition.json
+++ b/tests/Support/Fixtures/definitions/layouts/test-layout/v1/definition.json
@@ -5,6 +5,6 @@
 	"version": 1,
 	
 	"regions": [
-		"test-region"
+		"test-region-v1"
 	]
 }

--- a/tests/Support/Fixtures/definitions/regions/test-region-with-multiple-sections/v1/definition.json
+++ b/tests/Support/Fixtures/definitions/regions/test-region-with-multiple-sections/v1/definition.json
@@ -8,10 +8,10 @@
 		{
 			"name": "test-section",
 			"allowedBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"defaultBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"optional": false,
 			"min": 1,
@@ -20,10 +20,10 @@
 		{
 			"name": "test-section2",
 			"allowedBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"defaultBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"optional": false,
 			"min": 1,

--- a/tests/Support/Fixtures/definitions/regions/test-region-with-required-section/v1/definition.json
+++ b/tests/Support/Fixtures/definitions/regions/test-region-with-required-section/v1/definition.json
@@ -8,10 +8,10 @@
 		{
 			"name": "test-section",
 			"allowedBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"defaultBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"optional": false,
 			"min": 1,

--- a/tests/Support/Fixtures/definitions/regions/test-region/v1/definition.json
+++ b/tests/Support/Fixtures/definitions/regions/test-region/v1/definition.json
@@ -8,10 +8,10 @@
 		{
 			"name": "test-section",
 			"allowedBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"defaultBlocks": [
-				"test-block"
+				"test-block-v1"
 			],
 			"optional": true,
 			"min": 2,

--- a/tests/Unit/Http/Controllers/Api/v1/BlockControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/v1/BlockControllerTest.php
@@ -55,7 +55,7 @@ class BlockControllerTest extends ApiControllerTestCase {
      * @group authentication
      */
     public function definition_WhenUnauthenticated_Returns403(){
-        $response = $this->action('GET', BlockController::class . '@definition', 'test-block');
+        $response = $this->action('GET', BlockController::class . '@definition', 'test-block-v1');
         $response->assertStatus(401);
     }
 
@@ -77,7 +77,7 @@ class BlockControllerTest extends ApiControllerTestCase {
         Gate::shouldReceive('authorize')->with('read', Definition::class)->once();
 
         $this->authenticated();
-        $this->action('GET', BlockController::class . '@definition', 'test-block');
+        $this->action('GET', BlockController::class . '@definition', 'test-block-v1');
     }
 
     /**
@@ -87,7 +87,7 @@ class BlockControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthenticatedAndUnauthorized_Returns403(){
         $this->authenticatedAndUnauthorized();
 
-        $response = $this->action('GET', BlockController::class . '@definition', 'test-block');
+        $response = $this->action('GET', BlockController::class . '@definition', 'test-block-v1');
         $response->assertStatus(403);
     }
 
@@ -97,7 +97,7 @@ class BlockControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthorized_Returns200(){
         $this->authenticatedAndAuthorized();
 
-        $response = $this->action('GET', BlockController::class . '@definition', 'test-block');
+        $response = $this->action('GET', BlockController::class . '@definition', 'test-block-v1');
         $response->assertStatus(200);
     }
 
@@ -107,7 +107,7 @@ class BlockControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthorized_ReturnsJson(){
         $this->authenticatedAndAuthorized();
 
-        $response = $this->action('GET', BlockController::class . '@definition', 'test-block');
+        $response = $this->action('GET', BlockController::class . '@definition', 'test-block-v1');
 
         $json = $response->json();
         $this->assertArrayHasKey('data', $json);

--- a/tests/Unit/Http/Controllers/Api/v1/LayoutControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/v1/LayoutControllerTest.php
@@ -56,7 +56,7 @@ class LayoutControllerTest extends ApiControllerTestCase {
      * @group authentication
      */
     public function definition_WhenUnauthenticated_Returns403(){
-        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout');
+        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout-v1');
         $response->assertStatus(401);
     }
 
@@ -78,7 +78,7 @@ class LayoutControllerTest extends ApiControllerTestCase {
         Gate::shouldReceive('authorize')->with('read', Definition::class)->once();
 
         $this->authenticated();
-        $this->action('GET', LayoutController::class . '@definition', 'test-layout');
+        $this->action('GET', LayoutController::class . '@definition', 'test-layout-v1');
     }
 
     /**
@@ -88,7 +88,7 @@ class LayoutControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthenticatedAndUnauthorized_Returns403(){
         $this->authenticatedAndUnauthorized();
 
-        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout');
+        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout-v1');
         $response->assertStatus(403);
     }
 
@@ -98,7 +98,7 @@ class LayoutControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthorized_Returns200(){
         $this->authenticatedAndAuthorized();
 
-        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout');
+        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout-v1');
         $response->assertStatus(200);
     }
 
@@ -108,11 +108,12 @@ class LayoutControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthorizedAndFound_ReturnsJson(){
         $this->authenticatedAndAuthorized();
 
-        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout');
+        $response = $this->action('GET', LayoutController::class . '@definition', 'test-layout-v1');
 
         $json = $response->json();
         $this->assertArrayHasKey('data', $json);
         $this->assertEquals('test-layout', $json['data']['name']);
+        $this->assertEquals(1, $json['data']['version']);
     }
 
     /**
@@ -122,7 +123,7 @@ class LayoutControllerTest extends ApiControllerTestCase {
         $this->authenticatedAndAuthorized();
 
         $response = $this->action('GET', LayoutController::class . '@definition', [
-            'layout_definition' => 'test-layout',
+            'layout_definition' => 'test-layout-v1',
             'include' => 'region_definitions',
         ]);
 

--- a/tests/Unit/Http/Controllers/Api/v1/RegionControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/v1/RegionControllerTest.php
@@ -55,7 +55,7 @@ class RegionControllerTest extends ApiControllerTestCase {
      * @group authentication
      */
     public function definition_WhenUnauthenticated_Returns403(){
-        $response = $this->action('GET', RegionController::class . '@definition', 'test-region');
+        $response = $this->action('GET', RegionController::class . '@definition', 'test-region-v1');
         $response->assertStatus(401);
     }
 
@@ -77,7 +77,7 @@ class RegionControllerTest extends ApiControllerTestCase {
         Gate::shouldReceive('authorize')->with('read', Definition::class)->once();
 
         $this->authenticated();
-        $this->action('GET', RegionController::class . '@definition', 'test-region');
+        $this->action('GET', RegionController::class . '@definition', 'test-region-v1');
     }
 
     /**
@@ -87,7 +87,7 @@ class RegionControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthenticatedAndUnauthorized_Returns403(){
         $this->authenticatedAndUnauthorized();
 
-        $response = $this->action('GET', RegionController::class . '@definition', 'test-region');
+        $response = $this->action('GET', RegionController::class . '@definition', 'test-region-v1');
         $response->assertStatus(403);
     }
 
@@ -97,7 +97,7 @@ class RegionControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthorized_Returns200(){
         $this->authenticatedAndAuthorized();
 
-        $response = $this->action('GET', RegionController::class . '@definition', 'test-region');
+        $response = $this->action('GET', RegionController::class . '@definition', 'test-region-v1');
         $response->assertStatus(200);
     }
 
@@ -107,11 +107,12 @@ class RegionControllerTest extends ApiControllerTestCase {
     public function definition_WhenAuthorizedAndFound_ReturnsJson(){
         $this->authenticatedAndAuthorized();
 
-        $response = $this->action('GET', RegionController::class . '@definition', 'test-region');
+        $response = $this->action('GET', RegionController::class . '@definition', 'test-region-v1');
 
         $json = $response->json();
         $this->assertArrayHasKey('data', $json);
-        $this->assertEquals('test-region', $json['data']['name']);
+		$this->assertEquals('test-region', $json['data']['name']);
+		$this->assertEquals(1, $json['data']['version']);
     }
 
     /**
@@ -121,7 +122,7 @@ class RegionControllerTest extends ApiControllerTestCase {
         $this->authenticatedAndAuthorized();
 
         $response = $this->action('GET', RegionController::class . '@definition', [
-            'layout_definition' => 'test-region',
+            'layout_definition' => 'test-region-v1',
             'include' => 'block_definitions',
         ]);
 

--- a/tests/Unit/Http/Requests/Api/v1/Page/PersistRequestTest.php
+++ b/tests/Unit/Http/Requests/Api/v1/Page/PersistRequestTest.php
@@ -977,7 +977,7 @@ class PersistRequestTest extends RequestTestCase
 
         $rules = $validator->getRules();
         $this->assertArrayHasKey('blocks.test-region.0.definition_name', $rules);
-        $this->assertEquals('in:test-block', $rules['blocks.test-region.0.definition_name'][0]);
+        $this->assertEquals('in:test-block-v1', $rules['blocks.test-region.0.definition_name'][0]);
     }
 
 

--- a/tests/Unit/Models/APICommands/UpdateContentTest.php
+++ b/tests/Unit/Models/APICommands/UpdateContentTest.php
@@ -100,7 +100,8 @@ class UpdateContentTest extends APICommandTestCase
     {
         $update_content = new UpdateContent();
         $update_content->validateBlock([
-                    "definition_name" => "non-existent-test-block"
+                    "definition_name" => "non-existent-test-block",
+					"definition_version" => 1
                 ]);
     }
 
@@ -121,9 +122,10 @@ class UpdateContentTest extends APICommandTestCase
     {
         $valid_data = $this->input(null);
 
-        $valid_data['blocks']['test-region'][0]['blocks'] = [
+        $valid_data['blocks']['test-region-v1'][0]['blocks'] = [
                 [
-                    "definition_name" => "another-test-block"
+                    "definition_name" => "another-test-block-v1",
+					"definition_version" => 1
                 ]
             ];          
         $validator = $this->validator($valid_data);
@@ -174,10 +176,10 @@ class UpdateContentTest extends APICommandTestCase
     {
         $valid_data = $this->input(null);
 
-        $valid_data['blocks']['test-region-with-required-section'] = $valid_data['blocks']['test-region'];
-        unset($valid_data['blocks']['test-region']);
+        $valid_data['blocks']['test-region-with-required-section-v1'] = $valid_data['blocks']['test-region-v1'];
+        unset($valid_data['blocks']['test-region-v1']);
 
-        $valid_data['blocks']['test-region-with-required-section'][0]['blocks'] = [];
+        $valid_data['blocks']['test-region-with-required-section-v1'][0]['blocks'] = [];
 
         $validator = $this->validator($valid_data);
         $this->assertFalse($validator->passes());
@@ -191,7 +193,7 @@ class UpdateContentTest extends APICommandTestCase
     {
         $valid_data = $this->input(null);
 
-        $valid_data['blocks']['test-region'][0]['blocks'] = [];
+        $valid_data['blocks']['test-region-v1'][0]['blocks'] = [];
 
         $validator = $this->validator($valid_data);
         $this->assertTrue($validator->passes());
@@ -205,8 +207,8 @@ class UpdateContentTest extends APICommandTestCase
     {
         $valid_data = $this->input(null);
 
-        unset($valid_data['blocks']['test-region'][0]['blocks'][1]);
-        unset($valid_data['blocks']['test-region'][0]['blocks'][2]);
+        unset($valid_data['blocks']['test-region-v1'][0]['blocks'][1]);
+        unset($valid_data['blocks']['test-region-v1'][0]['blocks'][2]);
 
         $validator = $this->validator($valid_data);
         $this->assertFalse($validator->passes());
@@ -222,12 +224,12 @@ class UpdateContentTest extends APICommandTestCase
 
         // our sample page data input has 3 blocks in it, so we'll add 5 more 
         // so that it goes over the max amount of permitted blocks in our definition
-        $invalid_data['blocks']['test-region'][0]['blocks'][] = $invalid_data['blocks']['test-region'][0]['blocks'][1];
-        $invalid_data['blocks']['test-region'][0]['blocks'][] = $invalid_data['blocks']['test-region'][0]['blocks'][1];
-        $invalid_data['blocks']['test-region'][0]['blocks'][] = $invalid_data['blocks']['test-region'][0]['blocks'][1];
-        $invalid_data['blocks']['test-region'][0]['blocks'][] = $invalid_data['blocks']['test-region'][0]['blocks'][1];
-        $invalid_data['blocks']['test-region'][0]['blocks'][] = $invalid_data['blocks']['test-region'][0]['blocks'][1];
-        $invalid_data['blocks']['test-region'][0]['blocks'][] = $invalid_data['blocks']['test-region'][0]['blocks'][1];
+        $invalid_data['blocks']['test-region-v1'][0]['blocks'][] = $invalid_data['blocks']['test-region-v1'][0]['blocks'][1];
+        $invalid_data['blocks']['test-region-v1'][0]['blocks'][] = $invalid_data['blocks']['test-region-v1'][0]['blocks'][1];
+        $invalid_data['blocks']['test-region-v1'][0]['blocks'][] = $invalid_data['blocks']['test-region-v1'][0]['blocks'][1];
+        $invalid_data['blocks']['test-region-v1'][0]['blocks'][] = $invalid_data['blocks']['test-region-v1'][0]['blocks'][1];
+        $invalid_data['blocks']['test-region-v1'][0]['blocks'][] = $invalid_data['blocks']['test-region-v1'][0]['blocks'][1];
+        $invalid_data['blocks']['test-region-v1'][0]['blocks'][] = $invalid_data['blocks']['test-region-v1'][0]['blocks'][1];
 
 
         $validator = $this->validator($invalid_data);
@@ -263,7 +265,7 @@ class UpdateContentTest extends APICommandTestCase
         $invalid_data = $this->input(null);
         
         // test-region definition only allows one section
-        $invalid_data['blocks']['test-region'][] = $invalid_data['blocks']['test-region'][0];
+        $invalid_data['blocks']['test-region-v1'][] = $invalid_data['blocks']['test-region-v1'][0];
 
         $validator = $this->validator($invalid_data);
         $this->assertFalse($validator->passes());
@@ -278,7 +280,7 @@ class UpdateContentTest extends APICommandTestCase
         $invalid_data = $this->input(null);
         
         // test-region definition only allows one section
-        unset($invalid_data['blocks']['test-region'][0]);
+        unset($invalid_data['blocks']['test-region-v1'][0]);
 
         $validator = $this->validator($invalid_data);
         $this->assertFalse($validator->passes());
@@ -293,12 +295,12 @@ class UpdateContentTest extends APICommandTestCase
         $invalid_data = $this->input(null);
 
         // change the region definition being used to one with multiple sections
-        $invalid_data['blocks']['test-region-with-multiple-sections'] = $invalid_data['blocks']['test-region'];
-        unset($invalid_data['blocks']['test-region']);
+        $invalid_data['blocks']['test-region-with-multiple-sections-v1'] = $invalid_data['blocks']['test-region-v1'];
+        unset($invalid_data['blocks']['test-region-v1']);
 
         // add a second (permitted) section but in the wrong order
-        $invalid_data['blocks']['test-region-with-multiple-sections'][] = $invalid_data['blocks']['test-region-with-multiple-sections'][0];
-        $invalid_data['blocks']['test-region-with-multiple-sections'][0]['name'] = 'test-section2';
+        $invalid_data['blocks']['test-region-with-multiple-sections-v1'][] = $invalid_data['blocks']['test-region-with-multiple-sections-v1'][0];
+        $invalid_data['blocks']['test-region-with-multiple-sections-v1'][0]['name'] = 'test-section2';
 
 
         $validator = $this->validator($invalid_data);
@@ -313,7 +315,7 @@ class UpdateContentTest extends APICommandTestCase
     {
         $invalid_data = $this->input(null);
 
-        $invalid_data['blocks']['test-region'][0]['name'] = 'unknown-section';
+        $invalid_data['blocks']['test-region-v1'][0]['name'] = 'unknown-section';
 
         $validator = $this->validator($invalid_data);
         $this->assertFalse($validator->passes());

--- a/tests/Unit/Models/Definitions/BlockTest.php
+++ b/tests/Unit/Models/Definitions/BlockTest.php
@@ -18,7 +18,7 @@ class BlockTest extends TestCase
 	 * @test
 	 */
 	public function locateDefinition_WhenDefinitionIsFound_ReturnsPath(){
-		$path = Block::locateDefinition('test-block');
+		$path = Block::locateDefinition('test-block-v1');
 		$this->assertEquals(base_path('tests/Support/Fixtures/definitions/blocks/test-block/v1/definition.json'), $path);
 	}
 
@@ -33,7 +33,7 @@ class BlockTest extends TestCase
 	 * @test
 	 */
 	public function locateDefinitionOrFail_WhenDefinitionIsFound_ReturnsPath(){
-		$path = Block::locateDefinitionOrFail('test-block');
+		$path = Block::locateDefinitionOrFail('test-block-v1');
 		$this->assertEquals(base_path('tests/Support/Fixtures/definitions/blocks/test-block/v1/definition.json'), $path);
 	}
 

--- a/tests/Unit/Models/Definitions/LayoutTest.php
+++ b/tests/Unit/Models/Definitions/LayoutTest.php
@@ -20,7 +20,7 @@ class LayoutTest extends TestCase
 	 * @test
 	 */
 	public function locateDefinition_WhenDefinitionIsFound_ReturnsPath(){
-		$path = Layout::locateDefinition('test-layout');
+		$path = Layout::locateDefinition('test-layout-v1');
 		$this->assertEquals(base_path('tests/Support/Fixtures/definitions/layouts/test-layout/v1/definition.json'), $path);
 	}
 
@@ -35,7 +35,7 @@ class LayoutTest extends TestCase
 	 * @test
 	 */
 	public function locateDefinitionOrFail_WhenDefinitionIsFound_ReturnsPath(){
-		$path = Layout::locateDefinitionOrFail('test-layout');
+		$path = Layout::locateDefinitionOrFail('test-layout-v1');
 		$this->assertEquals(base_path('tests/Support/Fixtures/definitions/layouts/test-layout/v1/definition.json'), $path);
 	}
 
@@ -52,7 +52,7 @@ class LayoutTest extends TestCase
 	 * @test
 	 */
 	public function getRegionDefinitions_ReturnsCollection(){
-		$path = Layout::locateDefinition('test-layout');
+		$path = Layout::locateDefinition('test-layout-v1');
 		$layout = Layout::fromDefinitionFile($path);
 
 		$this->assertInstanceOf(Collection::class, $layout->getRegionDefinitions());
@@ -64,7 +64,7 @@ class LayoutTest extends TestCase
 	 * Note: the 'test-layout' fixture only supports 'test-region'
 	 */
 	public function getRegionDefinitions_WhenRegionDefinitionsAreNotLoaded_LoadsSupportedRegionDefinitionsIntoCollection(){
-		$path = Layout::locateDefinition('test-layout');
+		$path = Layout::locateDefinition('test-layout-v1');
 		$layout = Layout::fromDefinitionFile($path);
 
 		$collection = $layout->getRegionDefinitions();
@@ -78,7 +78,7 @@ class LayoutTest extends TestCase
 	 * Note: the 'test-layout' fixture only supports 'test-region'
 	 */
 	public function getRegionDefinitions_WhenRegionDefinitionsAreLoaded_DoesNotReloadRegionDefinitions(){
-		$path = Layout::locateDefinition('test-layout');
+		$path = Layout::locateDefinition('test-layout-v1');
 
 		$layout = Layout::fromDefinitionFile($path);
 		$layout->getRegionDefinitions(); 				// This should populate the Collection

--- a/tests/Unit/Models/Definitions/RegionTest.php
+++ b/tests/Unit/Models/Definitions/RegionTest.php
@@ -20,7 +20,7 @@ class RegionTest extends TestCase
 	 * @test
 	 */
 	public function locateDefinition_WhenDefinitionIsFound_ReturnsPath(){
-		$path = Region::locateDefinition('test-region');
+		$path = Region::locateDefinition('test-region-v1');
 		$this->assertEquals(base_path('tests/Support/Fixtures/definitions/regions/test-region/v1/definition.json'), $path);
 	}
 
@@ -35,7 +35,7 @@ class RegionTest extends TestCase
 	 * @test
 	 */
 	public function locateDefinitionOrFail_WhenDefinitionIsFound_ReturnsPath(){
-		$path = Region::locateDefinitionOrFail('test-region');
+		$path = Region::locateDefinitionOrFail('test-region-v1');
 		$this->assertEquals(base_path('tests/Support/Fixtures/definitions/regions/test-region/v1/definition.json'), $path);
 	}
 
@@ -52,7 +52,7 @@ class RegionTest extends TestCase
 	 * @test
 	 */
 	public function getBlockDefinitions_ReturnsCollection(){
-		$path = Region::locateDefinition('test-region');
+		$path = Region::locateDefinition('test-region-v1');
 		$region = Region::fromDefinitionFile($path);
 
 		$this->assertInstanceOf(Collection::class, $region->getBlockDefinitions());
@@ -64,7 +64,7 @@ class RegionTest extends TestCase
 	 * Note: the 'test-region' fixture only supports 'test-block'
 	 */
 	public function getBlockDefinitions_WhenBlockDefinitionsAreNotLoaded_LoadsSupportedBlockDefinitionsIntoCollection(){
-		$path = Region::locateDefinition('test-region');
+		$path = Region::locateDefinition('test-region-v1');
 		$region = Region::fromDefinitionFile($path);
 
 		$collection = $region->getBlockDefinitions();
@@ -78,7 +78,7 @@ class RegionTest extends TestCase
 	 * Note: the 'test-region' fixture only supports 'test-block'
 	 */
 	public function getBlockDefinitions_WhenBlockDefinitionsAreLoaded_DoesNotReloadBlockDefinitions(){
-		$path = Region::locateDefinition('test-region');
+		$path = Region::locateDefinition('test-region-v1');
 
 		$region = Region::fromDefinitionFile($path);
 		$region->getBlockDefinitions(); 				// This should populate the Collection

--- a/tests/Unit/Validation/Brokers/BlockBrokerTest.php
+++ b/tests/Unit/Validation/Brokers/BlockBrokerTest.php
@@ -21,7 +21,7 @@ class BlockBrokerTest extends TestCase
 
 		Config::set('app.definitions_path', base_path('tests/Support/Fixtures/definitions'));
 
-        $file = BlockDefinition::locateDefinition('test-block');
+        $file = BlockDefinition::locateDefinition('test-block-v1');
         $this->block = BlockDefinition::fromDefinitionFile($file);
 	}
 

--- a/tests/Unit/Validation/Brokers/RegionBrokerTest.php
+++ b/tests/Unit/Validation/Brokers/RegionBrokerTest.php
@@ -17,7 +17,7 @@ class RegionBrokerTest extends TestCase
 	 */
 	public function getSectionConstraintRules_CreatesRuleValidatingAllowedBlocks()
 	{
-        $file = RegionDefinition::locateDefinition('test-region', 1);
+        $file = RegionDefinition::locateDefinition('test-region-v1');
         $region = RegionDefinition::fromDefinitionFile($file);
 		$rv = new RegionBroker($region);
 
@@ -32,7 +32,7 @@ class RegionBrokerTest extends TestCase
 	 */
 	public function getSectionConstraintRules_CreatesRuleValidatingBlockLimits()
 	{
-        $file = RegionDefinition::locateDefinition('test-region');
+        $file = RegionDefinition::locateDefinition('test-region-v1');
         $region = RegionDefinition::fromDefinitionFile($file);
 		$rv = new RegionBroker($region);
 
@@ -48,7 +48,7 @@ class RegionBrokerTest extends TestCase
 	 */
 	public function getSectionConstraintRules_CreatesRuleValidatingBlockRequired()
 	{
-        $file = RegionDefinition::locateDefinition('test-region-with-required-section');
+        $file = RegionDefinition::locateDefinition('test-region-with-required-section-v1');
         $region = RegionDefinition::fromDefinitionFile($file);
 		$rv = new RegionBroker($region);
 

--- a/tests/Unit/Validation/Brokers/RegionBrokerTest.php
+++ b/tests/Unit/Validation/Brokers/RegionBrokerTest.php
@@ -17,14 +17,14 @@ class RegionBrokerTest extends TestCase
 	 */
 	public function getSectionConstraintRules_CreatesRuleValidatingAllowedBlocks()
 	{
-        $file = RegionDefinition::locateDefinition('test-region');
+        $file = RegionDefinition::locateDefinition('test-region', 1);
         $region = RegionDefinition::fromDefinitionFile($file);
 		$rv = new RegionBroker($region);
 
 		$rules = $rv->getSectionConstraintRules("test-section");
 
 		$this->assertArrayHasKey('definition_name', $rules['allowedBlocks']);
-		$this->assertEquals('in:test-block', $rules['allowedBlocks']['definition_name'][0]);
+		$this->assertEquals('inVersioned:{version},test-block-v1', $rules['allowedBlocks']['definition_name'][0]);
 	}
 
 	/**


### PR DESCRIPTION
See #166 

It may be worth merging whatever Justice and Christian have been working on before merging these changes...

This PR modifies Astro to explicitly require using {name}-v{version} syntax when referencing layouts, regions and blocks.

It requires the definitions branch https://github.com/unikent/cms-prototype-blocks/tree/wip/fix/require-versions-in-definition-ids to function.

It includes a migration to migrate any existing blocks or revisions to the new format.