### PR TITLE
Use layouts list as returned by the API for populating layout choices.

### DIFF
--- a/app/Http/Controllers/Api/v1/LayoutController.php
+++ b/app/Http/Controllers/Api/v1/LayoutController.php
@@ -32,9 +32,9 @@ class LayoutController extends ApiController
 	}
 
 	/**
-	 *
-	 * @param $layout_ids
-	 * @return array
+	 * Get layout definitions, indexed by layout_id
+	 * @param array $layout_ids - Array of layout ids to retrieve layouts for [ {name}-v{version}, ...]
+	 * @return array - Array of layout definitions, indexed by layout id
 	 */
 	public function getLayoutDefinitions($layout_ids)
 	{

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -4,18 +4,19 @@
 		<el-form-item label="Page title">
 			<el-input name="title" v-model="createForm.title" auto-complete="off"></el-input>
 		</el-form-item>
-		<el-select
-			name="layout_name"
-			v-model="createForm.layout_name"
-			@change="getLayout"
-		>
-			<el-option
-					v-for="item in layouts"
-					:key="item.name"
-					:label="item.label"
-					:value="item.name">
-			</el-option>
-		</el-select>
+		<el-form-item label="Layout">
+			<el-select
+				name="layout"
+				v-model="createForm.layout"
+			>
+				<el-option
+						v-for="(item, key) in layouts"
+						:key="key"
+						:label="item.label"
+						:value="key">
+				</el-option>
+			</el-select>
+		</el-form-item>
 		<el-form-item label="slug">
 			<el-input
 				name="slug"
@@ -42,31 +43,9 @@ export default {
 
 	data() {
 		return {
-			layouts: [
-				{
-					label: 'Kent homepage',
-					name: 'kent-homepage-v1'
-				},
-				{
-					label: 'Site homepage',
-					name: 'site-homepage-v1'
-				},
-				{
-					label: 'Content page',
-					name: 'content-v1'
-				},
-				{
-					label: 'School homepage',
-					name: 'school-homepage-v1'
-				},
-				{
-					label: 'School about us',
-					name: 'school-about-v1'
-				}
-			],
 			createForm: {
 				title: 'New page',
-				layout_name: 'site-homepage-v1',
+				layout: '',
 				route: {
 					slug: '',
 					parent_id: 1
@@ -81,7 +60,8 @@ export default {
 	computed: {
 		...mapState('site', {
 			pages: state => state.pages,
-			pageModal: state => state.pageModal
+			pageModal: state => state.pageModal,
+			layouts: state => state.layouts
 		}),
 
 		visible: {
@@ -103,7 +83,6 @@ export default {
 
 	created() {
 		this.fetchSite();
-		this.getLayout(this.createForm.layout_name);
 	},
 
 	methods: {
@@ -115,7 +94,7 @@ export default {
 
 		addChild() {
 			// if the user has not edited the slug then use the suggested slug
-			if (this.userEditingSlug ==  false) {
+			if (this.userEditingSlug ===  false) {
 				this.createForm.route.slug = this.suggestedSlug;
 			}
 			this.createPage(this.createForm);
@@ -133,7 +112,7 @@ export default {
 		resetForm() {
 			this.createForm = {
 				title: 'New page',
-				layout_name: 'site-homepage-v1',
+				layout: '',
 				route: {
 					slug: '',
 					parent_id: 1
@@ -142,54 +121,6 @@ export default {
 				options: {}
 			}
 		},
-
-		getLayout(layoutName) {
-			this.createForm.blocks = {};
-			this.$api
-				.get(`layouts/${layoutName}/definition?include=region_definitions.block_definitions`)
-				.then(({ data: json }) => {
-					// go through our region definitions
-					json.data.region_definitions.forEach((region) => {
-						// if "default" blocks have been set and
-						// we have some block definitions, try adding them
-						if(region.default && region.block_definitions) {
-
-							region.default.forEach((blockName) => {
-								// see if this particular block definition exists
-								const blockDefinition = region.block_definitions.find(
-									(def) => def.name === blockName
-								);
-
-								if(blockDefinition) {
-									if(!this.createForm.blocks[region.name]) {
-										this.createForm.blocks[region.name] = [];
-									}
-
-									// add our empty block
-									const length = this.createForm.blocks[region.name].push({
-										definition_name: blockDefinition.name,
-										definition_version: blockDefinition.version,
-										fields: {}
-									});
-
-									// fill in the block's fields with their default values
-									Definition.fillBlockFields(
-										this.createForm.blocks[region.name][length - 1],
-										blockDefinition
-									)
-
-									// add them to our create form (not directly
-									// modifying the property so it can react to changes)
-									this.createForm = {
-										...this.createForm,
-										blocks: this.createForm.blocks
-									};
-								}
-							});
-						}
-					});
-				});
-		}
 	}
 };
 </script>

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -7,13 +7,16 @@
 		<el-form-item label="Layout">
 			<el-select
 				name="layout"
+				class="w100"
+				placeholder="Select"
 				v-model="createForm.layout"
 			>
 				<el-option
-						v-for="(item, key) in layouts"
+						v-for="(layout, key) in layouts"
+						:label="layout.label + ' (v' + layout.version + ')'"
+						:value="layout"
 						:key="key"
-						:label="item.label"
-						:value="key">
+				>
 				</el-option>
 			</el-select>
 		</el-form-item>

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -12,10 +12,10 @@
 				v-model="createForm.layout"
 			>
 				<el-option
-						v-for="(layout, key) in layouts"
-						:label="layout.label + ' (v' + layout.version + ')'"
-						:value="layout"
-						:key="key"
+						v-for="(layoutDefinition, layoutID) in layouts"
+						:label="layoutDefinition.label + ' (v' + layoutDefinition.version + ')'"
+						:value="layoutID"
+						:key="layoutID"
 				>
 				</el-option>
 			</el-select>
@@ -30,7 +30,7 @@
 	</el-form>
 	<span slot="footer" class="dialog-footer">
 	<el-button @click="visible = false">Cancel</el-button>
-	<el-button type="primary" @click="addChild">Confirm</el-button>
+	<el-button type="primary" @click="addChild" :disabled="disableSubmit">Confirm</el-button>
 </span>
 </el-dialog>
 </template>
@@ -67,6 +67,12 @@ export default {
 			layouts: state => state.layouts
 		}),
 
+		disableSubmit() {
+			return this.createForm.layout === ''	 ||
+				this.createForm.title === '' ||
+				this.createForm.route.slug === '';
+		},
+
 		visible: {
 			get() {
 				this.createForm.route.parent_id = this.pageModal.parentId;
@@ -100,7 +106,10 @@ export default {
 			if (this.userEditingSlug ===  false) {
 				this.createForm.route.slug = this.suggestedSlug;
 			}
-			this.createPage(this.createForm);
+			this.createPage({...this.createForm, layout: {
+				name: this.layouts[this.createForm.layout].name,
+				version: this.layouts[this.createForm.layout].version
+			}});
 			this.resetForm();
 			this.visible = false;
 		},

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -94,6 +94,7 @@ TODO: Add last published date after the page status
 		mounted() {
 			this.loadPermissions();
 			this.loadGlobalRole(window.astro.username);
+			this.$store.dispatch('site/fetchLayouts');
 		},
 
 		computed: {

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -224,8 +224,8 @@ const actions = {
 				parent_id: page.route.parent_id,
 				slug: page.route.slug,
 				layout: {
-					name: page.layout.replace(/-v[0-9]+$/, ''),
-					version: page.layout.replace(/^.+?-v([0-9]+)$/, '$1'),
+					name: page.layout.name,
+					version: page.layout.version,
 				},
 				title: page.title
 			})

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -198,6 +198,10 @@ const actions = {
 			});
 	},
 
+	/**
+	 * Initialise the list of layouts available for use.
+	 * @param commit
+	 */
 	fetchLayouts({ commit }) {
 		api
 			.get('layouts/definitions')
@@ -220,8 +224,8 @@ const actions = {
 				parent_id: page.route.parent_id,
 				slug: page.route.slug,
 				layout: {
-					name: page.layout_name.replace(/-v[0-9]+$/, ''),
-					version: page.layout_name.replace(/^.+?-v([0-9]+)$/, '$1'),
+					name: page.layout.replace(/-v[0-9]+$/, ''),
+					version: page.layout.replace(/^.+?-v([0-9]+)$/, '$1'),
 				},
 				title: page.title
 			})

--- a/resources/assets/js/views/App.vue
+++ b/resources/assets/js/views/App.vue
@@ -18,11 +18,6 @@ export default {
 		SnackBar
 	},
 
-	created: function() {
-		// initialise the layouts in one place...
-		this.$store.dispatch('site/fetchLayouts');
-	},
-
 	computed: {
 		...mapState([
 			'wrapperStyles'

--- a/resources/assets/js/views/App.vue
+++ b/resources/assets/js/views/App.vue
@@ -18,11 +18,15 @@ export default {
 		SnackBar
 	},
 
+	created: function() {
+		// initialise the layouts in one place...
+		this.$store.dispatch('site/fetchLayouts');
+	},
+
 	computed: {
 		...mapState([
 			'wrapperStyles'
 		]),
-
 		isEditor() {
 			return ['preview', '404'].indexOf(this.$route.name) === -1;
 		}

--- a/resources/assets/js/views/SiteList.vue
+++ b/resources/assets/js/views/SiteList.vue
@@ -9,19 +9,20 @@ Permission checking - we're checking on two admin only permissions which are not
 1. site.create
 2. site.delete
 This shouldn't matter, since admin is a 'let them do anything' switch,  but if we need to add them we should make the names consistent. 
- */
+*/
 <template>
-<el-card>
-	<div slot="header" class="manage-table__header">
-		<span class="main-header">Manage sites</span>
-		<el-button v-if="canUser('site.create')" type="default" @click="dialogFormVisible = true" class="manage-table__add-button">
-			Add Site
-		</el-button>
-	</div>
+	<el-card>
+		<div slot="header" class="manage-table__header">
+			<span class="main-header">Manage sites</span>
+			<el-button v-if="canUser('site.create')" type="default" @click="dialogFormVisible = true"
+					   class="manage-table__add-button">
+				Add Site
+			</el-button>
+		</div>
 
-	<div class="el-table w100 el-table--fit el-table--striped el-table--border el-table--enable-row-hover">
-		<table cellspacing="0" cellpadding="0" border="0" class="w100">
-			<thead>
+		<div class="el-table w100 el-table--fit el-table--striped el-table--border el-table--enable-row-hover">
+			<table cellspacing="0" cellpadding="0" border="0" class="w100">
+				<thead>
 				<tr>
 					<th>
 						<div class="cell">
@@ -42,12 +43,12 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 					</th>
 
 				</tr>
-			</thead>
-			<tbody v-loading.body="loading">
+				</thead>
+				<tbody v-loading.body="loading">
 				<tr
-				v-for="site in sitesWithRoles"
-				:key="site.id"
-				class="el-table__row"
+						v-for="site in sitesWithRoles"
+						:key="site.id"
+						class="el-table__row"
 				>
 					<td>
 						<div class="cell">
@@ -63,271 +64,270 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 
 					<td>
 						<div class="cell">
-							<router-link :to="`/site/${site.id}/menu`" v-if="canUserOnSite('site.options.edit', site.currentRole)">
+							<router-link :to="`/site/${site.id}/menu`"
+										 v-if="canUserOnSite('site.options.edit', site.currentRole)">
 								<el-button type="default" size="small">
 									Menu
 								</el-button>
 							</router-link>
-							<router-link :to="`/site/${site.id}/users`" v-if="canUserOnSite('permissions.site.assign', site.currentRole)">
+							<router-link :to="`/site/${site.id}/users`"
+										 v-if="canUserOnSite('permissions.site.assign', site.currentRole)">
 								<el-button type="default" size="small">
 									Manage users
 								</el-button>
 							</router-link>
-							<el-button @click="askRemove(site.id)" type="default" size="small" v-if="canUserOnSite('site.delete', site.currentRole)">
-								<icon name="delete" width="14" height="14" />
+							<el-button @click="askRemove(site.id)" type="default" size="small"
+									   v-if="canUserOnSite('site.delete', site.currentRole)">
+								<icon name="delete" width="14" height="14"/>
 							</el-button>
 						</div>
 					</td>
 
 
 				</tr>
-			</tbody>
-		</table>
+				</tbody>
+			</table>
 
-		<el-dialog title="Add Site" v-model="dialogFormVisible">
-			<el-form :model="form" label-position="top">
-				<el-row type="flex" :gutter="20">
+			<el-dialog title="Add Site" v-model="dialogFormVisible">
+				<el-form :model="form" label-position="top">
+					<el-row type="flex" :gutter="20">
 
-					<el-col :span="11">
+						<el-col :span="11">
 
-						<el-form-item label="Name">
-							<el-input v-model="form.name" auto-complete="off"></el-input>
-						</el-form-item>
-					</el-col>
+							<el-form-item label="Name">
+								<el-input v-model="form.name" auto-complete="off"></el-input>
+							</el-form-item>
+						</el-col>
 
-					<el-col :span="11" :offset="2">
-						<el-form-item label="Home page layout">
-							<el-select v-model="form.homepage_layout" class="w100" placeholder="Select">
-								<el-option v-for="layout in layouts" :label="layout.name" :value="layout" :key="layout.name" />
-							</el-select>
-						</el-form-item>
-					</el-col>
+						<el-col :span="11" :offset="2">
+							<el-form-item label="Home page layout">
+								<el-select v-model="form.homepage_layout" class="w100" placeholder="Select">
+									<el-option v-for="(layout, key) in layouts"
+											   :label="layout.label + ' (v' + layout.version + ')'"
+											   :value="layout"
+											   :key="key"
+									>
+									</el-option>
+								</el-select>
+							</el-form-item>
+						</el-col>
 
-				</el-row>
+					</el-row>
 
-				<el-row type="flex" :gutter="20">
+					<el-row type="flex" :gutter="20">
 
-					<el-col :span="11">
+						<el-col :span="11">
 
-						<el-form-item label="Host">
-							<el-input v-model="form.host" auto-complete="off" placeholder="www.kent.ac.uk"></el-input>
-						</el-form-item>
+							<el-form-item label="Host">
+								<el-input v-model="form.host" auto-complete="off"
+										  placeholder="www.kent.ac.uk"></el-input>
+							</el-form-item>
 
-					</el-col>
+						</el-col>
 
-					<el-col :span="11" :offset="2">
+						<el-col :span="11" :offset="2">
 
-						<el-form-item label="Path">
-							<el-input v-model="form.path" auto-complete="off" placeholder=""></el-input>
-						</el-form-item>
-					</el-col>
+							<el-form-item label="Path">
+								<el-input v-model="form.path" auto-complete="off" placeholder=""></el-input>
+							</el-form-item>
+						</el-col>
 
-				</el-row>
+					</el-row>
 
-				<div class="el-alert el-alert--error" v-if="form.errorMsgs">
-					<i class="el-alert__icon el-icon-circle-cross is-big"></i>
-					<div class="el-alert__content">
-						<span class="el-alert__title is-bold">{{form.errorMsgs}}</span>
-						<ul v-for="error in form.errorsDetails" :key="error.id">
-							<li class="el-alert__description">{{error}}</li>
-						</ul>
+					<div class="el-alert el-alert--error" v-if="form.errorMsgs">
+						<i class="el-alert__icon el-icon-circle-cross is-big"></i>
+						<div class="el-alert__content">
+							<span class="el-alert__title is-bold">{{form.errorMsgs}}</span>
+							<ul v-for="error in form.errorsDetails" :key="error.id">
+								<li class="el-alert__description">{{error}}</li>
+							</ul>
+						</div>
 					</div>
-				</div>
 
-			</el-form>
-			<span slot="footer" class="dialog-footer">
+				</el-form>
+				<span slot="footer" class="dialog-footer">
 				<el-button @click="cancelForm">Cancel</el-button>
 				<el-button type="primary" @click="addSite">Add Site</el-button>
 			</span>
-		</el-dialog>
-	</div>
-</el-card>
+			</el-dialog>
+		</div>
+	</el-card>
 </template>
 
 <script>
-import Icon from 'components/Icon';
-import { mapGetters } from 'vuex';
-import permissions  from 'store/modules/permissions'; // this is to use canUser directly and provide our own state for each site in the list
+	import Icon from 'components/Icon';
+	import {mapGetters, mapState} from 'vuex';
+	import permissions  from 'store/modules/permissions'; // this is to use canUser directly and provide our own state for each site in the list
 
-export default {
+	export default {
 
-	components: {
-		Icon
-	},
+		components: {
+			Icon
+		},
 
-	data() {
-		return {
-			sites: [],
-			layouts: [],
-			dialogFormVisible: false,
-			loading: true,
-
-			form: {
-				name: '',
-				path: '',
-				host: '',
-				homepage_layout: '',
-				errors: '',
-			}
-		};
-	},
-
-	created() {
-		this.fetchData();
-	},
-
-	computed: {
-
-		...mapGetters([
-			'canUser',
-			'getPermissions',
-			'getGlobalRole'
-		]),
-
-
-		sitesWithRoles: function() {
-			let sitesWithRoles = [];
-
-			for (var i = 0, len = this.sites.length; i < len; i++) {
-				// if the site has a role for the user then add the currentRole to the list of sites
-				let currentSite = this.sites[i];
-				currentSite['currentRole'] = ''; // set a default
-				if (currentSite.users) {
-					let result = currentSite.users.find((element) => element.username === window.astro.username);
-					if (result) {
-						currentSite['currentRole'] = result.role;
-					}
+		data() {
+			return {
+				sites: [],
+				dialogFormVisible: false,
+				loading: true,
+				form: {
+					name: '',
+					path: '',
+					host: '',
+					homepage_layout: '',
+					errors: '',
 				}
-
-			  sitesWithRoles.push(currentSite);
-			}
-			return sitesWithRoles;
-		}
-	},
-
-	methods: {
-
-		/**
-		 * a wrapper around canUser which provides a fake state to make it work in the context
-		 * of sites which are not loaded into the vuex state 
-		 * 
-		 * @param {string} permissionSlug - the slug of the permission ie. page.publish
-		 * @param {string} siteRole - the role the user has on the site ie. site.owner
-		 */
-		canUserOnSite(permissionSlug, siteRole) {
-			let siteState = {};
-			siteState.currentRole = siteRole;
-			siteState.permissions = this.getPermissions;
-			siteState.globalRole = this.getGlobalRole;
-	
-			return permissions.getters.canUser(siteState)(permissionSlug);
-		},
-
-		// TODO: delete site is not yet implemented!
-		askRemove(index) {
-			this.$confirm(
-				`Site ${index} will be permanently removed.\nAre you sure?`,
-				'Warning',
-				{
-					confirmButtonText: 'OK',
-					cancelButtonText: 'Cancel',
-					type: 'warning'
-				}
-			).then(() => {
-				this.$message({
-					type: 'success',
-					message: 'Delete completed'
-				});
-			}).catch(() => {});
-		},
-
-		cancelForm() {
-			this.dialogFormVisible = false;
-			// reset the form
-			this.resetForm();
-		},
-
-		resetForm() {
-			this.form = {
-				name: '',
-				host: '',
-				path: '',
-				errors: '',
-				homepage_layout: ''
 			};
-			this.loading = false;
 		},
 
-		addSite() {
-			this.loading = true;
-			this.dialogFormVisible = false;
-
-			// paths needs to be blank or a srting starting with a /
-			if (this.form.path.length != 0) {
-				if (this.form.path[0] != '/') {
-					this.form.path = '/' + this.form.path;
-				}
-			}
-			let site = {};
-
-			site = ({
-				name: this.form.name,
-				host: this.form.host,
-				path: this.form.path,
-				homepage_layout: {
-					name: this.form.homepage_layout.name,
-					version: this.form.homepage_layout.version
-				}
-			});
-
-			this.form.errors = [];
-			this.$api
-				.post('sites', site)
-				.then(() => {
-					// success, so let's refresh what data as have from the api
-					this.fetchData();
-
-					// reset the form
-					this.resetForm();
-
-				})
-				.catch((errors) => {
-					this.dialogFormVisible = true;
-					this.form.errorMsgs = errors.response.data.errors[0].message;
-					this.form.errorsDetails = errors.response.data.errors[0].details;
-					this.loading = false;
-				});
+		created() {
+			this.fetchData();
 		},
 
-		fetchData() {
-			const fetchSites = this.$api.get('sites?include=homepage.revision,users');
-			const fetchLayouts = this.$api.get('layouts/definitions');
+		computed: {
+			...mapState({
+				layouts: state => state.site.layouts
+			}),
+			...mapGetters([
+				'canUser',
+				'getPermissions',
+				'getGlobalRole'
+			]),
 
-			// make sure we get all the data back before continuing
-			this.$api
-				.all([fetchSites, fetchLayouts])
-				.then(this.$api.spread((sites, layouts) => {
+			allLayouts: function() {
+				return this.layouts;
+			},
 
-					this.sites = sites.data.data;
-					this.layouts = [];
-					layouts = layouts.data.data;
+			sitesWithRoles: function() {
+				let sitesWithRoles = [];
 
-					for(var i = layouts.length - 1; i >= 0; i--) {
-						// TODO: this should return an array of layout definitions
-						// so for now we are faking this and setting the version numbers to 1
-						let currentLayout = [];
-						currentLayout.name = layouts[i];
-						currentLayout.version = '1';
-						this.layouts.push(currentLayout);
+				for (var i = 0, len = this.sites.length; i < len; i++) {
+					// if the site has a role for the user then add the currentRole to the list of sites
+					let currentSite = this.sites[i];
+					currentSite['currentRole'] = ''; // set a default
+					if (currentSite.users) {
+						let result = currentSite.users.find((element) => element.username === window.astro.username);
+						if (result) {
+							currentSite['currentRole'] = result.role;
+						}
 					}
+					sitesWithRoles.push(currentSite);
+				}
+				return sitesWithRoles;
+			}
+		},
 
-					// now we have all the data unhide the list
-					this.loading = false;
-				}))
-				.catch((errors) => {
-					// TODO: what do we do when the API is unavaliable
+		methods: {
+
+			/**
+			 * a wrapper around canUser which provides a fake state to make it work in the context
+			 * of sites which are not loaded into the vuex state
+			 *
+			 * @param {string} permissionSlug - the slug of the permission ie. page.publish
+			 * @param {string} siteRole - the role the user has on the site ie. site.owner
+			 */
+			canUserOnSite(permissionSlug, siteRole) {
+				let siteState = {};
+				siteState.currentRole = siteRole;
+				siteState.permissions = this.getPermissions;
+				siteState.globalRole = this.getGlobalRole;
+
+				return permissions.getters.canUser(siteState)(permissionSlug);
+			},
+
+			// TODO: delete site is not yet implemented!
+			askRemove(index) {
+				this.$confirm(
+					`Site ${index} will be permanently removed.\nAre you sure?`,
+					'Warning',
+					{
+						confirmButtonText: 'OK',
+						cancelButtonText: 'Cancel',
+						type: 'warning'
+					}
+				).then(() => {
+					this.$message({
+						type: 'success',
+						message: 'Delete completed'
+					});
+				}).catch(() => {
 				});
+			},
+
+			cancelForm() {
+				this.dialogFormVisible = false;
+				// reset the form
+				this.resetForm();
+			},
+
+			resetForm() {
+				this.form = {
+					name: '',
+					host: '',
+					path: '',
+					errors: '',
+					homepage_layout: ''
+				};
+				this.loading = false;
+			},
+
+			addSite() {
+				this.loading = true;
+				this.dialogFormVisible = false;
+
+				// paths needs to be blank or a srting starting with a /
+				if (this.form.path.length != 0) {
+					if (this.form.path[0] != '/') {
+						this.form.path = '/' + this.form.path;
+					}
+				}
+				let site = {};
+
+				site = ({
+					name: this.form.name,
+					host: this.form.host,
+					path: this.form.path,
+					homepage_layout: {
+						name: this.form.homepage_layout.name,
+						version: this.form.homepage_layout.version
+					}
+				});
+
+				this.form.errors = [];
+				this.$api
+					.post('sites', site)
+					.then(() => {
+						// success, so let's refresh what data as have from the api
+						this.fetchData();
+
+						// reset the form
+						this.resetForm();
+
+					})
+					.catch((errors) => {
+						this.dialogFormVisible = true;
+						this.form.errorMsgs = errors.response.data.errors[0].message;
+						this.form.errorsDetails = errors.response.data.errors[0].details;
+						this.loading = false;
+					});
+			},
+
+			fetchData() {
+				const fetchSites = this.$api.get('sites?include=homepage.revision,users');
+
+				// make sure we get all the data back before continuing
+				this.$api
+					.all([fetchSites])
+					.then(this.$api.spread((sites) => {
+
+						this.sites = sites.data.data;
+						// now we have all the data unhide the list
+						this.loading = false;
+					}))
+					.catch((errors) => {
+						// TODO: what do we do when the API is unavaliable
+					});
+			}
 		}
-	}
-};
+	};
 </script>

--- a/resources/assets/js/views/SiteList.vue
+++ b/resources/assets/js/views/SiteList.vue
@@ -102,10 +102,10 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 						<el-col :span="11" :offset="2">
 							<el-form-item label="Home page layout">
 								<el-select v-model="form.homepage_layout" class="w100" placeholder="Select">
-									<el-option v-for="(layout, key) in layouts"
-											   :label="layout.label + ' (v' + layout.version + ')'"
-											   :value="layout"
-											   :key="key"
+									<el-option v-for="(layoutDefinition, layoutID) in layouts"
+											   :label="layoutDefinition.label + ' (v' + layoutDefinition.version + ')'"
+											   :value="layoutID"
+											   :key="layoutID"
 									>
 									</el-option>
 								</el-select>
@@ -147,7 +147,7 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 				</el-form>
 				<span slot="footer" class="dialog-footer">
 				<el-button @click="cancelForm">Cancel</el-button>
-				<el-button type="primary" @click="addSite">Add Site</el-button>
+				<el-button type="primary" @click="addSite" :disabled="disableSubmit">Add Site</el-button>
 			</span>
 			</el-dialog>
 		</div>
@@ -185,6 +185,13 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 		},
 
 		computed: {
+
+			disableSubmit() {
+				return this.form.homepage_layout === ''	 ||
+						this.form.name === '' ||
+						this.form.host === '';
+			},
+
 			...mapState({
 				layouts: state => state.site.layouts
 			}),
@@ -193,10 +200,6 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 				'getPermissions',
 				'getGlobalRole'
 			]),
-
-			allLayouts: function() {
-				return this.layouts;
-			},
 
 			sitesWithRoles: function() {
 				let sitesWithRoles = [];
@@ -281,17 +284,16 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 						this.form.path = '/' + this.form.path;
 					}
 				}
-				let site = {};
 
-				site = ({
+				let site = {
 					name: this.form.name,
 					host: this.form.host,
 					path: this.form.path,
 					homepage_layout: {
-						name: this.form.homepage_layout.name,
-						version: this.form.homepage_layout.version
+						name: this.layouts[this.form.homepage_layout].name,
+						version: this.layouts[this.form.homepage_layout].version
 					}
-				});
+				};
 
 				this.form.errors = [];
 				this.$api


### PR DESCRIPTION
The create site and add page dialogues used different lists of layouts.

This PR uses loads a list of layouts into the state using the API and then uses this list for both of these dialogues, and also displays the layout version in the list of choices.