### PR TITLE
WIP - Site definitions (Templates)

### DIFF
--- a/app/Http/Controllers/Api/v1/SiteController.php
+++ b/app/Http/Controllers/Api/v1/SiteController.php
@@ -52,7 +52,7 @@ class SiteController extends ApiController
 			$request->get('name'),
 			$request->get('host'),
 			$request->get('path'),
-			$request->get('homepage_layout', []),
+			$request->get('site_definition', []),
 			$request->get('options')
 		);
 		if ($site instanceof Site) {

--- a/app/Http/Controllers/Api/v1/SiteController.php
+++ b/app/Http/Controllers/Api/v1/SiteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\v1;
 
 use App\Models\APICommands\UpdateSite;
+use App\Models\Definitions\SiteDefinition;
 use App\Models\LocalAPIClient;
 use App\Models\Page;
 use App\Models\Permission;
@@ -12,6 +13,7 @@ use Illuminate\Http\Request;
 use App\Http\Transformers\Api\v1\SiteTransformer;
 use App\Http\Transformers\Api\v1\PageTransformer;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -186,4 +188,34 @@ class SiteController extends ApiController
 		return $map[null]['children'];
 	}
 
+	/**
+	 * GET /sites/definitions
+	 * Get a list of available site definitions.
+	 */
+	public function definitions()
+	{
+		$this->authorize('index', SiteDefinition::class);
+		$path = sprintf('%s/%s/', Config::get('app.definitions_path'), SiteDefinition::$defDir);
+		$sites = glob($path . '*/v*/definition.json');
+		$path_length = strlen($path);
+		foreach($sites as &$site){
+			$site = preg_replace('/\/(v[0-9]+)\/definition\.json$/', '-$1', substr($site, $path_length));
+		}
+		$site_definitions = $this->getSiteDefinitions($sites);
+		return response()->json([ 'data' => $site_definitions ]);
+	}
+
+		/**
+		 * Get site definitions, indexed by {name}-v{version}
+		 * @param array $site_ids - Array of site ids to retrieve definitions for [ {name}-v{version}, ...]
+		 * @return array - Array of site definitions, indexed by site id
+		 */
+	public function getSiteDefinitions($site_ids)
+	{
+		$sites = [];
+		foreach($site_ids as $site_id) {
+			$sites[$site_id] = SiteDefinition::fromDefinitionFile(SiteDefinition::locateDefinition($site_id));
+		}
+		return $sites;
+	}
 }

--- a/app/Models/APICommands/AddPage.php
+++ b/app/Models/APICommands/AddPage.php
@@ -2,11 +2,8 @@
 
 namespace App\Models\APICommands;
 
-use App\Models\Definitions\Contracts\Definition;
-use App\Models\Definitions\Layout;
 use App\Models\Revision;
 use DB;
-use App\Models\Block;
 use App\Models\Page;
 use App\Models\RevisionSet;
 use App\Models\Contracts\APICommand;
@@ -20,6 +17,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
  */
 class AddPage implements APICommand
 {
+	use AddsPagesTrait;
 
     /**
      * Adding a Page
@@ -30,7 +28,7 @@ class AddPage implements APICommand
     {
         return DB::transaction(function() use($input, $user){
             $parent = Page::find($input['parent_id']);
-            $page = $this->addChild($parent,
+            $page = $this->addPage($parent,
                 $input['slug'],
                 $input['title'],
                 $user,
@@ -42,45 +40,6 @@ class AddPage implements APICommand
             }
             return $page;
         });
-    }
-
-
-    /**
-     * Adds a new page (creating a revision) at the end of this page's children.
-     * @param string $slug The slug for the new page, must not already exist under this parent.
-     * @param string $title The title for the new page.
-     * @param Authenticatable $user The user account to set as the creator.
-     * @param string $layout_name The name of the layout for this page.
-     * @param int $layout_version The version of the layout for this page.
-     * @return Page
-     */
-    public function addChild($parent, $slug, $title, $user, $layout_name, $layout_version)
-    {
-        $page = $parent->children()->create(
-            [
-                'site_id' => $parent->site_id,
-                'version' => Page::STATE_DRAFT,
-                'slug' => $slug,
-                'parent_id' => $parent->id,
-                'created_by' => $user->id,
-                'updated_by' => $user->id
-            ]
-        );
-        $page->createDefaultBlocks($layout_name, $layout_version);
-        $revision_set = RevisionSet::create(['site_id' => $parent->site_id]);
-        $revision = Revision::create([
-            'revision_set_id' => $revision_set->id,
-            'title' => $title,
-            'created_by' => $user->id,
-            'updated_by' => $user->id,
-            'layout_name' => $layout_name,
-            'layout_version' => $layout_version,
-            'blocks' => $page->bake(),
-            'options' => null,
-			'valid' => true
-        ]);
-        $page->setRevision($revision);
-        return $page;
     }
 
     public function messages(Collection $data, Authenticatable $user)

--- a/app/Models/APICommands/AddsPagesTrait.php
+++ b/app/Models/APICommands/AddsPagesTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models\APICommands;
+
+use App\Models\Page;
+use App\Models\Revision;
+use App\Models\RevisionSet;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Functionality to add a page as a subpage of an existing page.
+ * @package App\Models\APICommands
+ */
+trait AddsPagesTrait
+{
+	/**
+	 * Adds a new page (creating a revision) at the end of this page's children.
+	 * @param Page $parent The Page object which will be a parent to this page.
+	 * @param string $slug The slug for the new page, must not already exist under this parent.
+	 * @param string $title The title for the new page.
+	 * @param Authenticatable $user The user account to set as the creator.
+	 * @param string $layout_name The name of the layout for this page.
+	 * @param int $layout_version The version of the layout for this page.
+	 * @return Page - The newly added page.
+	 */
+	public function addPage($parent, $slug, $title, $user, $layout_name, $layout_version)
+	{
+		$page = $parent->children()->create(
+			[
+				'site_id' => $parent->site_id,
+				'version' => Page::STATE_DRAFT,
+				'slug' => $slug,
+				'parent_id' => $parent->id,
+				'created_by' => $user->id,
+				'updated_by' => $user->id
+			]
+		);
+		$page->createDefaultBlocks($layout_name, $layout_version);
+		$revision_set = RevisionSet::create(['site_id' => $parent->site_id]);
+		$revision = Revision::create([
+			'revision_set_id' => $revision_set->id,
+			'title' => $title,
+			'created_by' => $user->id,
+			'updated_by' => $user->id,
+			'layout_name' => $layout_name,
+			'layout_version' => $layout_version,
+			'blocks' => $page->bake(),
+			'options' => null,
+			'valid' => true
+		]);
+		$page->setRevision($revision);
+		return $page;
+	}
+}

--- a/app/Models/Definitions/BaseDefinition.php
+++ b/app/Models/Definitions/BaseDefinition.php
@@ -370,7 +370,7 @@ abstract class BaseDefinition implements Arrayable, DefinitionContract, Jsonable
      *
      * @param  string $definition_id - The {name}-v{version} string identifying the definition.
      * @param  int $version
-     * @throws App\Exceptions\DefinitionNotFoundException
+     * @throws DefinitionNotFoundException
      * @return string
      */
     public static function locateDefinitionOrFail($definition_id){

--- a/app/Models/Definitions/SiteDefinition.php
+++ b/app/Models/Definitions/SiteDefinition.php
@@ -1,0 +1,42 @@
+<?php
+namespace App\Models\Definitions;
+
+use Illuminate\Support\Collection;
+
+class SiteDefinition extends BaseDefinition
+{
+
+	public static $defDir = 'sites';
+
+	protected $casts = [
+        'allowedLayouts' => 'array',
+	];
+
+	/**
+	 * Loads the Region definitions from disk and populates $regionDefinitions.
+	 *
+	 * @return void
+	 */
+	public function loadRegionDefinitions(){
+		foreach($this->regions as $region_id){
+			$path = Region::locateDefinition($region_id);
+			if(!is_null($path)){
+				$region = Region::fromDefinitionFile($path);
+				$this->regionDefinitions->push($region);
+			}
+		}
+	}
+
+	/**
+	 * Returns the regionDefinitions Collection, populating it from disk if necessary.
+	 *
+	 * @return Collection
+	 */
+	public function getRegionDefinitions(){
+		if($this->regionDefinitions->isEmpty() && count($this->regions)){
+			$this->loadRegionDefinitions();
+		}
+
+		return $this->regionDefinitions;
+	}
+}

--- a/app/Models/Definitions/SiteDefinition.php
+++ b/app/Models/Definitions/SiteDefinition.php
@@ -9,7 +9,7 @@ class SiteDefinition extends BaseDefinition
 	public static $defDir = 'sites';
 
 	protected $casts = [
-        'allowedLayouts' => 'array',
+        'allowedLayouts' => 'array'
 	];
 
 	/**

--- a/app/Models/Definitions/SiteDefinition.php
+++ b/app/Models/Definitions/SiteDefinition.php
@@ -11,32 +11,4 @@ class SiteDefinition extends BaseDefinition
 	protected $casts = [
         'allowedLayouts' => 'array'
 	];
-
-	/**
-	 * Loads the Region definitions from disk and populates $regionDefinitions.
-	 *
-	 * @return void
-	 */
-	public function loadRegionDefinitions(){
-		foreach($this->regions as $region_id){
-			$path = Region::locateDefinition($region_id);
-			if(!is_null($path)){
-				$region = Region::fromDefinitionFile($path);
-				$this->regionDefinitions->push($region);
-			}
-		}
-	}
-
-	/**
-	 * Returns the regionDefinitions Collection, populating it from disk if necessary.
-	 *
-	 * @return Collection
-	 */
-	public function getRegionDefinitions(){
-		if($this->regionDefinitions->isEmpty() && count($this->regions)){
-			$this->loadRegionDefinitions();
-		}
-
-		return $this->regionDefinitions;
-	}
 }

--- a/app/Models/LocalAPIClient.php
+++ b/app/Models/LocalAPIClient.php
@@ -127,17 +127,17 @@ class LocalAPIClient implements APIClient
 	 * @param string $name Name for the new site.
 	 * @param string $host Hostname for the new site.
 	 * @param string $path Path for the new site.
-	 * @param array $homepage_layout layout to use for the homepage for this site. [ 'name' => '...', 'version' => '...']
+	 * @param array $site_definition - The Site template to use for this site. [ 'name' => '...', 'version' => '...']
 	 * @param array $options Other options.
 	 * @return Site|object
 	 */
-	public function createSite($name, $host, $path, $homepage_layout, $options = [])
+	public function createSite($name, $host, $path, $site_definition, $options = [])
 	{
 		return $this->execute(CreateSite::class, [
 			'name' => $name,
 			'host' => $host,
 			'path' => $path,
-			'homepage_layout' => $homepage_layout,
+			'site_definition' => $site_definition,
 			'options' => $options
 		]);
 	}

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -15,7 +15,8 @@ class Site extends Model
         'path',
         'created_by',
         'updated_by',
-
+		'site_definition_name',
+		'site_definition_version',
         'options'
     ];
 

--- a/app/Policies/Definitions/SiteDefinitionPolicy.php
+++ b/app/Policies/Definitions/SiteDefinitionPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies\Definitions;
+
+use App\Policies\BasePolicy;
+use App\Models\User;
+use App\Models\Definitions\SiteDefinition;
+
+class SiteDefinitionPolicy extends BasePolicy
+{
+    /**
+     * Determine whether the user can index definitions.
+     *
+     * @param  User  $user
+     * @return boolean
+     */
+    public function index(User $user)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the definition.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Definitions\Layout  $definition
+     * @return boolean
+     */
+    public function read(User $user, SiteDefinition $definition)
+    {
+        return true;
+    }
+
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\APICommands\PublishPage;
 use App\Models\Definitions\BaseDefinition;
+use App\Models\Definitions\SiteDefinition;
 use App\Models\Page;
 use App\Validation\Rules\LayoutExistsRule;
 use App\Validation\Rules\UniqueSitePathRule;
@@ -89,7 +90,15 @@ class AppServiceProvider extends ServiceProvider
 		});
 
 		Validator::extend('layout_exists', function($attribute, $value, $parameters, $validator){
-		   return (new LayoutExistsRule(empty($parameters[0]) ? 0 : $parameters[0]))->passes($attribute,$value);
+			return (new LayoutExistsRule(empty($parameters[0]) ? 0 : $parameters[0]))->passes($attribute,$value);
+		});
+
+		/**
+		 * Checks if a requested site template definition exists.
+		 * usage in validation rules: ['definition_name_field' => 'site_definition_exists:{version}']
+		 */
+		Validator::extend('site_definition_exists', function($attribute, $value, $parameters, $validator){
+			return SiteDefinition::locateDefinition(SiteDefinition::idFromNameAndVersion($value,$parameters[0]));
 		});
 
 		Validator::extend('definition_exists', function ($attribute, $value, $parameters, $validator){

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,9 +16,11 @@ use App\Policies\MediaPolicy;
 use App\Models\Definitions\Block as BlockDefinition;
 use App\Models\Definitions\Layout as LayoutDefinition;
 use App\Models\Definitions\Region as RegionDefinition;
+use App\Models\Definitions\SiteDefinition;
 use App\Policies\Definitions\BlockPolicy as BlockDefinitionPolicy;
 use App\Policies\Definitions\LayoutPolicy as LayoutDefinitionPolicy;
 use App\Policies\Definitions\RegionPolicy as RegionDefinitionPolicy;
+use App\Policies\Definitions\SiteDefinitionPolicy;
 use App\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -36,6 +38,7 @@ class AuthServiceProvider extends ServiceProvider
 		BlockDefinition::class => BlockDefinitionPolicy::class,
 		LayoutDefinition::class => LayoutDefinitionPolicy::class,
 		RegionDefinition::class => RegionDefinitionPolicy::class,
+		SiteDefinition::class => SiteDefinitionPolicy::class,
 		User::class => UserPolicy::class,
 		Permission::class => PermissionPolicy::class,
 		Role::class => RolePolicy::class

--- a/database/migrations/2017_11_30_145150_add_site_template_name_and_version_to_sites.php
+++ b/database/migrations/2017_11_30_145150_add_site_template_name_and_version_to_sites.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSiteTemplateNameAndVersionToSites extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->string('site_definition_name', 100)->default('');
+            $table->unsignedSmallInteger('site_definition_version', false)->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->dropIfExists('site_definition_name');
+            $table->dropIfExists('site_definition_version');
+        });
+    }
+}

--- a/database/migrations/2017_11_30_145150_add_site_template_name_and_version_to_sites.php
+++ b/database/migrations/2017_11_30_145150_add_site_template_name_and_version_to_sites.php
@@ -27,8 +27,7 @@ class AddSiteTemplateNameAndVersionToSites extends Migration
     public function down()
     {
         Schema::table('sites', function (Blueprint $table) {
-            $table->dropIfExists('site_definition_name');
-            $table->dropIfExists('site_definition_version');
+            $table->dropColumn(['site_definition_name', 'site_definition_version']);
         });
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -22,42 +22,6 @@ class DatabaseSeeder extends Seeder
 		'blocks'
 	];
 
-    public $testTree = [
-        [
-            'slug' => 'undergraduate',
-            'title' => 'Undergraduates',
-            'layout' => [ 'name' => 'content', 'version' => 1],
-            'children' => [
-                [
-                    'slug' => '2017',
-                    'title' => '2017 Entry',
-                    'layout' => [ 'name' => 'content', 'version' => 1],
-                ],
-                [
-                    'slug' => '2018',
-                    'title' => '2018 Entry',
-                    'layout' => [ 'name' => 'content', 'version' => 1],
-                ],
-            ]
-        ],
-        [
-            'slug' => 'postgraduate',
-            'title' => 'Postgraduates',
-            'layout' => [ 'name' => 'content', 'version' => 1],
-            'children' => [
-                [
-                    'slug' => '2017',
-                    'title' => '2017 Entry',
-                    'layout' => [ 'name' => 'content', 'version' => 1],
-                ],
-                [
-                    'slug' => '2018',
-                    'title' => '2018 Entry',
-                    'layout' => [ 'name' => 'content', 'version' => 1],
-                ],
-            ]
-        ]
-    ];
 
 	/**
 	 * Run the database seeds.
@@ -110,16 +74,9 @@ class DatabaseSeeder extends Seeder
 
 		$client = new LocalAPIClient($user);
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name'=>'site-homepage','version'=>1]
+            'Test Site', 'example.com', '', ['name'=>'school-site','version'=>1]
         );
-        $client->addTree( $site->draftHomepage->id, null, $this->testTree);
         $client->publishPage(Page::forSiteAndPath($site->id, '/')->first()->id);
-        $client->publishPage(Page::forSiteAndPath($site->id, '/postgraduate')->first()->id);
-        $client->publishPage(Page::forSiteAndPath($site->id, '/postgraduate/2018')->first()->id);
-        $client->publishPage(Page::forSiteAndPath($site->id, '/postgraduate/2017')->first()->id);
-        $client->publishPage(Page::forSiteAndPath($site->id, '/undergraduate')->first()->id);
-        $client->publishPage(Page::forSiteAndPath($site->id, '/undergraduate/2017')->first()->id);
-        $client->publishPage(Page::forSiteAndPath($site->id, '/undergraduate/2018')->first()->id);
 
 		$client->updateSiteUserRole($site->id,'editor', Role::EDITOR);
 		$client->updateSiteUserRole($site->id,'owner', Role::OWNER);

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -95,6 +95,7 @@ TODO: Add last published date after the page status
 			this.loadPermissions();
 			this.loadGlobalRole(window.astro.username);
 			this.$store.dispatch('site/fetchLayouts');
+			this.$store.dispatch('site/fetchSiteDefinitions');
 		},
 
 		computed: {

--- a/resources/assets/js/console/commands/validate.js
+++ b/resources/assets/js/console/commands/validate.js
@@ -13,7 +13,7 @@ const envPath = path.resolve(`${__dirname}/../../../../../.env`);
 dotenv.config({ path: envPath });
 
 const
-	schemas = ['layout', 'region', 'block'],
+	schemas = ['layout', 'region', 'block', 'site'],
 	ajv = new Ajv({ $data: true }),
 	validators = schemas.reduce((validators, schemaName) => {
 		const schemaPath = path.resolve(

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -40,6 +40,7 @@ const state = {
 	pages: [],
 	site: 1,
 	layouts: [],
+	siteDefinitions: {},
 	maxDepth: 3,
 	pageModal: {
 		visible: false,
@@ -73,6 +74,15 @@ const mutations = {
 
 	setLayouts(state, layouts) {
 		state.layouts = layouts;
+	},
+
+	/**
+	 * Sets the available site template definitions that can be selected from when creating a site.
+	 * @param state
+	 * @param {Object} definitions - { <name>-v<version>: {SiteDefinition}, ... }
+	 */
+	setSiteDefinitions(state, definitions) {
+		state.siteDefinitions = definitions;
 	},
 
 	addPage(state, { parent, index, page, push = false }) {
@@ -207,6 +217,18 @@ const actions = {
 			.get('layouts/definitions')
 			.then((response) => {
 				commit('setLayouts', response.data.data)
+			})
+	},
+
+	/**
+	 * Initialise the list of site definitions available for use.
+	 * @param commit
+	 */
+	fetchSiteDefinitions({ commit }) {
+		api
+			.get('sitedefinitions')
+			.then((response) => {
+				commit('setSiteDefinitions', response.data.data)
 			})
 	},
 

--- a/resources/assets/js/test/schemas/site.spec.json
+++ b/resources/assets/js/test/schemas/site.spec.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"type": "object",
+	"properties": {
+		"name": { "type": "string" },
+		"label": { "type": "string" },
+		"version": { "type": "integer", "default": 1 },
+		"availableLayouts": { "type": "array", "items": { "$ref": "#/definitions/layoutName" } },
+		"defaultPages": { "$ref": "#/definitions/page" }
+	},
+	"required": ["name", "label", "version", "defaultPages" ],
+	"definitions": {
+		"layoutName": {
+			"type": "string",
+			"pattern": "^[a-z]+(?:-+[a-z]+)*-v\\d+$"
+		},
+		"page": {
+			"type": "object",
+			"properties": {
+				"slug": { "$ref": "#/definitions/slug" },
+				"title": { "type": "string" },
+				"layout": { "$ref": "#/definitions/layoutName" },
+				"children": { "type": "array", "items": { "$ref": "#/definitions/page" } }
+			},
+			"required": ["slug", "title", "layout"]
+		},
+		"slug": {
+			"type": "string",
+			"pattern": "^[a-z0-9A-Z-]*$"
+		}
+	}
+}

--- a/resources/assets/js/views/SiteList.vue
+++ b/resources/assets/js/views/SiteList.vue
@@ -96,13 +96,13 @@ This shouldn't matter, since admin is a 'let them do anything' switch,  but if w
 					</el-col>
 
 					<el-col :span="11" :offset="2">
-						<el-form-item label="Home page layout">
-							<el-select v-model="form.homepage_layout" class="w100" placeholder="Select">
+						<el-form-item label="Site Template">
+							<el-select v-model="form.siteDefinitionId" class="w100" placeholder="Select">
 								<el-option
-									v-for="(layoutDefinition, layoutID) in layouts"
-									:label="layoutDefinition.label + ' (v' + layoutDefinition.version + ')'"
-									:value="layoutID"
-									:key="layoutID"
+									v-for="(siteDefinition, siteID) in siteDefinitions"
+									:label="siteDefinition.label + ' (v' + siteDefinition.version + ')'"
+									:value="siteID"
+									:key="siteID"
 								>
 								</el-option>
 							</el-select>
@@ -175,9 +175,7 @@ export default {
 				name: '',
 				path: '',
 				host: '',
-				/* eslint-disable camelcase */
-				homepage_layout: '',
-				/* eslint-enable camelcase */
+				siteDefinitionId: '',
 				errors: '',
 			}
 		};
@@ -190,7 +188,7 @@ export default {
 	computed: {
 
 		...mapState({
-			layouts: state => state.site.layouts
+			siteDefinitions: state => state.site.siteDefinitions
 		}),
 
 		...mapGetters([
@@ -200,7 +198,7 @@ export default {
 		]),
 
 		disableSubmit() {
-			return this.form.homepage_layout === ''	 ||
+			return this.form.siteDefinitionId === ''	 ||
 					this.form.name === '' ||
 					this.form.host === '';
 		},
@@ -274,7 +272,7 @@ export default {
 				path: '',
 				errors: '',
 				/* eslint-disable camelcase */
-				homepage_layout: ''
+				siteDefinitionId: ''
 				/* eslint-enable camelcase */
 			};
 			this.loading = false;
@@ -296,9 +294,9 @@ export default {
 				host: this.form.host,
 				path: this.form.path,
 				/* eslint-disable camelcase */
-				homepage_layout: {
-					name: this.layouts[this.form.homepage_layout].name,
-					version: this.layouts[this.form.homepage_layout].version
+				site_definition: {
+					name: this.siteDefinitions[this.form.siteDefinitionId].name,
+					version: this.siteDefinitions[this.form.siteDefinitionId].version
 				}
 				/* eslint-enable camelcase */
 			};

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::group(['prefix' => 'v1', 'namespace' => 'v1'], function () {
 	Route::get('routes/resolve', 'PageController@resolve');
 
 	Route::resource('sites', 'SiteController', ['only' => ['index', 'show', 'store', 'update', 'destroy']]);
+	Route::get('sitedefinitions', 'SiteController@definitions');
 	Route::get('sites/{site}/tree', 'SiteController@tree');
 	Route::patch('sites/{site}/tree', 'SiteController@move');
 

--- a/tests/Support/Astro.postman_collection.json
+++ b/tests/Support/Astro.postman_collection.json
@@ -196,7 +196,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\": \"Test site\",\n\t\"host\": \"astro.test\",\n\t\"path\": \"/sam/sayys\",\n\t\"homepage_layout\": {\n\t\t\"name\": \"kent-homepage\",\n\t\t\"version\": \"1\"\n\t}\n}"
+					"raw": "{\n\t\"name\": \"Latest Site\",\n\t\"host\": \"astro.test\",\n\t\"path\": \"/sam/says/i\",\n\t\"site_definition\": {\n\t\t\"name\": \"school-site\",\n\t\t\"version\": \"1\"\n\t}\n}"
 				},
 				"description": "Create a new Site."
 			},
@@ -339,7 +339,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"parent_id\": \"1\",\n\t\"slug\": \"feeinfo\",\n\t\"layout_name\": \"kent-homepage\",\n\t\"layout_version\": \"1\",\n\t\"title\": \"Undergraduate Fees\"\n}"
+					"raw": "{\n\t\"parent_id\": \"1\",\n\t\"slug\": \"feeinfo\",\n\t\"layout\": {\n\t\t\"name\": \"kent-homepage\",\n\t\t\"version\": \"1\"\n\t},\n\t\"title\": \"Undergraduate Fees\"\n}"
 				},
 				"description": "Create a new Site."
 			},
@@ -408,29 +408,7 @@
 		{
 			"name": "Layouts List",
 			"request": {
-				"url": {
-					"raw": "http://astro.test:8080/api/v1/sites?include=publishing_group,homepage.draft,drafts",
-					"protocol": "http",
-					"host": [
-						"astro",
-						"test"
-					],
-					"port": "8080",
-					"path": [
-						"api",
-						"v1",
-						"sites"
-					],
-					"query": [
-						{
-							"key": "include",
-							"value": "publishing_group,homepage.draft,drafts",
-							"equals": true,
-							"description": ""
-						}
-					],
-					"variable": []
-				},
+				"url": "http://astro.test:8080/api/v1/layouts/definitions",
 				"method": "GET",
 				"header": [
 					{
@@ -703,6 +681,36 @@
 					},
 					{
 						"key": "Accepts",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"description": "Retrieve a list of Sites."
+			},
+			"response": []
+		},
+		{
+			"name": "Site Definitions List - GET",
+			"request": {
+				"url": "http://astro.test:8080/api/v1/sites/definitions",
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer test",
+						"description": ""
+					},
+					{
+						"key": "accepts",
+						"value": "application/json",
+						"description": ""
+					},
+					{
+						"key": "content-type",
 						"value": "application/json",
 						"description": ""
 					}

--- a/tests/Support/Fixtures/definitions/sites/one-page-site/v1/definition.json
+++ b/tests/Support/Fixtures/definitions/sites/one-page-site/v1/definition.json
@@ -2,7 +2,7 @@
 	"name": "one-page-site",
 	"version": 1,
 	"label": "A single page site template for testing",
-	"pages": {
+	"defaultPages": {
 		"slug": "",
 		"title": "Home Page",
 		"layout": "test-layout-v1",

--- a/tests/Support/Fixtures/definitions/sites/one-page-site/v1/definition.json
+++ b/tests/Support/Fixtures/definitions/sites/one-page-site/v1/definition.json
@@ -1,0 +1,11 @@
+{
+	"name": "one-page-site",
+	"version": 1,
+	"label": "A single page site template for testing",
+	"pages": {
+		"slug": "",
+		"title": "Home Page",
+		"layout": "test-layout-v1",
+		"children": []
+	}
+}

--- a/tests/Unit/Models/APICommands/AddPageTest.php
+++ b/tests/Unit/Models/APICommands/AddPageTest.php
@@ -26,7 +26,7 @@ class AddPageTest extends APICommandTestCase
     public function getValidData()
     {
         $this->site = $this->site ? $this->site : $this->api()->createSite('Test Site', 'example.org', null, [
-            'name' => 'test-layout',
+            'name' => 'one-page-site',
             'version' => 1
         ]);
         return [

--- a/tests/Unit/Models/APICommands/CreateSiteTest.php
+++ b/tests/Unit/Models/APICommands/CreateSiteTest.php
@@ -32,8 +32,8 @@ class CreateSiteTest extends APICommandTestCase
             'name' => 'A Valid Name',
             'host' => 'example.com',
             'path' => '',
-            'homepage_layout' => [
-                'name' => 'test-layout',
+            'template_definition' => [
+                'name' => 'one-page-site',
                 'version' => 1
             ]
         ];
@@ -193,15 +193,15 @@ class CreateSiteTest extends APICommandTestCase
      * @test
      * @group APICommands
      */
-    public function validation_whenDefaultLayoutNameIsMissingOrInvalid_fails()
+    public function validation_whenSiteDefinitionNameIsMissingOrInvalid_fails()
     {
-        $data = $this->input(['homepage_layout' => ['name' => '', 'layout' => 1]]);
+        $data = $this->input(['site_definition' => ['name' => '', 'version' => 1]]);
         $this->assertTrue($this->validator($data)->fails());
-        $data = $this->input(['homepage_layout' => ['name' => '//£*', 'layout' => 1]]);
+        $data = $this->input(['site_definition' => ['name' => '//£*', 'version' => 1]]);
         $this->assertTrue($this->validator($data)->fails());
-        $data = $this->input(['homepage_layout' => null ]);
+        $data = $this->input(['site_definition' => null ]);
         $this->assertTrue($this->validator($data)->fails());
-        $data = $this->input(null,['homepage_layout']);
+        $data = $this->input(null,['site_definition']);
         $this->assertTrue($this->validator($data)->fails());
     }
 
@@ -209,14 +209,14 @@ class CreateSiteTest extends APICommandTestCase
      * @test
      * @group APICommands
      */
-    public function validation_whenDefaultLayoutVersionIsMissingOrInvalid_fails()
+    public function validation_whenSiteDefinitionVersionIsMissingOrInvalid_fails()
     {
         $data = $this->input([]);
-        unset($data['homepage_layout']['version']);
+        unset($data['site_definition']['version']);
         $this->assertTrue($this->validator($data)->fails());
-        $data['homepage_layout']['version'] = 'v1';
+        $data['site_definition']['version'] = 'v1';
         $this->assertTrue($this->validator($data)->fails());
-        $data['homepage_layout']['version'] = '';
+        $data['site_definition']['version'] = '';
         $this->assertTrue($this->validator($data)->fails());
     }
 
@@ -224,13 +224,13 @@ class CreateSiteTest extends APICommandTestCase
      * @test
      * @group APICommands
      */
-    public function validation_whenDefaultLayoutDefinitionNotFound_fails()
+    public function validation_whenSiteDefinitionNotFound_fails()
     {
         $data = $this->input([]);
-        $data['homepage_layout']['name'] = 'missing-layout-name';
+        $data['site_definition']['name'] = 'missing-layout-name';
         $this->assertTrue($this->validator($data)->fails());
-        $data['homepage_layout']['name'] = 'test-layout';
-        $data['homepage_layout']['version'] = 22;
+        $data['site_definition']['name'] = 'one-page-site';
+        $data['site_definition']['version'] = 22;
         $this->assertTrue($this->validator($data)->fails());
     }
 

--- a/tests/Unit/Models/APICommands/CreateSiteTest.php
+++ b/tests/Unit/Models/APICommands/CreateSiteTest.php
@@ -32,7 +32,7 @@ class CreateSiteTest extends APICommandTestCase
             'name' => 'A Valid Name',
             'host' => 'example.com',
             'path' => '',
-            'template_definition' => [
+            'site_definition' => [
                 'name' => 'one-page-site',
                 'version' => 1
             ]

--- a/tests/Unit/Models/APICommands/DeletePageTest.php
+++ b/tests/Unit/Models/APICommands/DeletePageTest.php
@@ -18,7 +18,7 @@ class DeletePageTest extends APICommandTestCase
     public function getValidData()
     {
         $this->site = $this->site ? $this->site : $this->api()->createSite('Test Site', 'example.org', null, [
-            'name' => 'test-layout',
+            'name' => 'one-page-site',
             'version' => 1
         ]);
         $page = $this->api()->addPage($this->site->draftHomepage->id, null, 'foo', $this->test_layout, 'Foo');

--- a/tests/Unit/Models/APICommands/MovePageTest.php
+++ b/tests/Unit/Models/APICommands/MovePageTest.php
@@ -18,7 +18,7 @@ class MovePageTest extends APICommandTestCase
     public function getValidData()
     {
         $this->site = $this->site ? $this->site : $this->api()->createSite('Test Site', 'example.org', null, [
-            'name' => 'test-layout',
+            'name' => 'one-page-site',
             'version' => 1
         ]);
         $page = $this->api()->addPage($this->site->draftHomepage->id, null, 'foo', $this->test_layout, 'Foo');

--- a/tests/Unit/Models/APICommands/UpdateSiteTest.php
+++ b/tests/Unit/Models/APICommands/UpdateSiteTest.php
@@ -39,7 +39,7 @@ class UpdateSiteTest extends APICommandTestCase
     public function validation_whenValidSiteButNoFieldsAreProvided_fails()
     {
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "one-page-site", "version" => 1]);
 
         $validator = $this->validator(['id' => $site->id] );
         $this->assertTrue($validator->fails());
@@ -52,7 +52,7 @@ class UpdateSiteTest extends APICommandTestCase
     public function validation_whenOptionsIsPresentButNotArray_fails()
     {
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "one-page-site", "version" => 1]);
 
         $validator = $this->validator([
             'id' => $site->id,
@@ -71,7 +71,7 @@ class UpdateSiteTest extends APICommandTestCase
     public function validation_whenOptionsIsArray_passes()
     {
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "one-page-site", "version" => 1]);
 
         $validator = $this->validator([
             'id' => $site->id,
@@ -90,7 +90,7 @@ class UpdateSiteTest extends APICommandTestCase
     {
         // given we have a site
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "one-page-site", "version" => 1]);
         
         // with some options
         $orignalOptions = [
@@ -121,7 +121,7 @@ class UpdateSiteTest extends APICommandTestCase
     {
         // given we have a site
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite("Test", "kent.ac.uk", "", [ "name" => "one-page-site", "version" => 1]);
         
         // with some options
         $orignalOptions = [
@@ -153,7 +153,7 @@ class UpdateSiteTest extends APICommandTestCase
         // given we have a site with an original name
         $originalName = 'Test Site Name';
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite( $originalName, "kent.ac.uk", "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite( $originalName, "kent.ac.uk", "", [ "name" => "one-page-site", "version" => 1]);
         
         // and we change the name
         $updatedName = 'Updated Test Site Name';
@@ -173,7 +173,7 @@ class UpdateSiteTest extends APICommandTestCase
         // given we have a site with an original path
         $originalPath = "/original";
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite('Site Name', "kent.ac.uk", $originalPath, [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite('Site Name', "kent.ac.uk", $originalPath, [ "name" => "one-page-site", "version" => 1]);
 
         // and we change the path
         $updatedPath = "/updated";
@@ -193,7 +193,7 @@ class UpdateSiteTest extends APICommandTestCase
         // given we have a site with an original path
         $originalHost = "lancaster.ac.uk";
         $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-        $site = $api->createSite('Site Name', $originalHost, "", [ "name" => "test-layout", "version" => 1]);
+        $site = $api->createSite('Site Name', $originalHost, "", [ "name" => "one-page-site", "version" => 1]);
         
         // and we change the path
         $updatedHost = "kent.ac.uk";
@@ -212,7 +212,7 @@ class UpdateSiteTest extends APICommandTestCase
     {
          // given we have a site
          $api = new LocalAPIClient(factory(\App\Models\User::class)->create());
-         $site = $api->createSite('Site Name', 'kent.ac.uk', "", [ "name" => "test-layout", "version" => 1]);
+         $site = $api->createSite('Site Name', 'kent.ac.uk', "", [ "name" => "one-page-site", "version" => 1]);
 
          // when we update a field
          $updatedName = 'Redesigned Site Name';

--- a/tests/Unit/Models/LocalAPIClientTest.php
+++ b/tests/Unit/Models/LocalAPIClientTest.php
@@ -66,11 +66,13 @@ class LocalAPIClientTest extends TestCase
     {
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $this->assertInstanceOf(Site::class, $site);
         $this->assertInstanceOf(Page::class, $site->draftHomepage);
+        $this->assertNull($site->draftHomepage->slug);
         $this->assertInstanceOf(Revision::class, $site->draftHomepage->revision);
+		$this->assertEquals('Home Page', $site->draftHomepage->revision->title); // as defined in the one-page-site-v1 site template
     }
 
     /**

--- a/tests/Unit/Models/LocalAPIClientTest.php
+++ b/tests/Unit/Models/LocalAPIClientTest.php
@@ -83,7 +83,7 @@ class LocalAPIClientTest extends TestCase
     {
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $new_page_title = 'This is a page :)';
         $newpage = $client->addPage(
@@ -109,7 +109,7 @@ class LocalAPIClientTest extends TestCase
     {
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $client->addTree($site->draftHomepage->id, null, $this->testTree);
         $expected = [
@@ -132,7 +132,7 @@ class LocalAPIClientTest extends TestCase
     {
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $client->addTree($site->draftHomepage->id, null, $this->testTree);
         $parent = Page::findBySiteAndPath($site->id,'/undergraduate');
@@ -166,7 +166,7 @@ class LocalAPIClientTest extends TestCase
         $this->expectException(\Illuminate\Validation\ValidationException::class);
         $client = $this->fixture();
         $site = $client->createSite(
-             'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+             'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $new_page_title = 'This is a page :)';
         $newpage = $client->addPage(
@@ -188,7 +188,7 @@ class LocalAPIClientTest extends TestCase
         $this->expectException(\Illuminate\Validation\ValidationException::class);
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $new_page_title = 'This is a page :)';
         $newpage = $client->addPage(
@@ -217,7 +217,7 @@ class LocalAPIClientTest extends TestCase
         $this->expectException(\Illuminate\Validation\ValidationException::class);
         $client = $this->fixture();
         $site = $client->createSite(
-             'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+             'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $client->addTree( $site->draftHomepage->id, null, $this->testTree);
         $parent1 = Page::findBySiteAndPath($site->id, '/undergraduate/2018');
@@ -260,7 +260,7 @@ class LocalAPIClientTest extends TestCase
         $this->expectException(\Illuminate\Validation\ValidationException::class);
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $client->updatePageContent(null, []);
     }
@@ -274,7 +274,7 @@ class LocalAPIClientTest extends TestCase
         $this->expectException(\Illuminate\Validation\ValidationException::class);
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $client->updatePageContent($site->draftHomepage->id, null);
     }
@@ -287,7 +287,7 @@ class LocalAPIClientTest extends TestCase
     {
         $client = $this->fixture();
         $site = $client->createSite(
-            'Test Site', 'example.com', '', ['name' => 'test-layout', 'version' => 1]
+            'Test Site', 'example.com', '', ['name' => 'one-page-site', 'version' => 1]
         );
         $homepage = $site->draftHomepage;
         $old_revision = $homepage->revision;

--- a/tests/Unit/Models/PageTest.php
+++ b/tests/Unit/Models/PageTest.php
@@ -38,7 +38,7 @@ class PageTest extends TestCase
             'test',
             'example.com',
             '',
-            ['name' => 'test-layout', 'version' => 1]
+            ['name' => 'one-page-site', 'version' => 1]
         );
         $api->publishPage($site->draftHomepage->id);
 	    $pages = Page::published()->get();
@@ -59,7 +59,7 @@ class PageTest extends TestCase
             'test',
             'example.com',
             '',
-            ['name' => 'test-layout', 'version' => 1]
+            ['name' => 'one-page-site', 'version' => 1]
         );
         $api->publishPage($site->draftHomepage->id);
         $pages = Page::draft()->get();
@@ -80,7 +80,7 @@ class PageTest extends TestCase
             'test',
             'example.com',
             '',
-            ['name' => 'test-layout', 'version' => 1]
+            ['name' => 'one-page-site', 'version' => 1]
         );
         $api->publishPage($site->draftHomepage->id);
         $pages = Page::version(Page::STATE_DRAFT)->get();


### PR DESCRIPTION
This PR adds site templates.

When creating a site users now select a site template instead of a homepage layout template, which defines the standard pages that should be created for the new site (their slug, title, layout and any subpages).

Site templates have their own definitions (similar to layouts, regions and blocks), stored in the definitions folder as:

` /sites/{template-name}/v{version}/definition.json`

A json schema for site definitions has been added, and they are validated (alongside other definitions) using the command:

`yarn run validate`

**This branch requires the https://github.com/unikent/cms-prototype-blocks/tree/feature/site-definitions definitions branch (until that has been merged into epic/templates)**

Still TODO is filtering the list of layouts available to the user when adding a page to only include those listed in the site's template definition availableLayouts array.
