### PR TITLE
Restrict available layouts in add page dialog to those that are allowed in the current site.

### DIFF
--- a/app/Http/Transformers/Api/v1/SiteTransformer.php
+++ b/app/Http/Transformers/Api/v1/SiteTransformer.php
@@ -57,7 +57,9 @@ class SiteTransformer extends FractalTransformer
             'created_at' => $site->created_at ? $site->created_at->__toString() : null,
             'updated_at' => $site->updated_at ? $site->updated_at->__toString() : null,
             'deleted_at' => $site->deleted_at ? $site->deleted_at->__toString() : null,
-			'options' => $site->options ? $site->options : new ArrayObject
+			'options' => $site->options ? $site->options : new ArrayObject,
+			'site_definition_name' => $site->site_definition_name,
+			'site_definition_version' => $site->site_definition_version
         ];
 		return $data;
 	}

--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex';
+import { mapState, mapActions, mapGetters } from 'vuex';
 import { Definition } from 'classes/helpers';
 import { slugify } from 'underscore.string';
 
@@ -64,8 +64,32 @@ export default {
 		...mapState('site', {
 			pages: state => state.pages,
 			pageModal: state => state.pageModal,
-			layouts: state => state.layouts
+			allLayouts: state => state.layouts
 		}),
+
+		...mapGetters([
+			'siteDefinition'
+		]),
+
+		layouts() {
+			if(this.siteDefinition){
+				if(this.siteDefinition.availableLayouts !== void 0) {
+					let available = {};
+					this.siteDefinition.availableLayouts.forEach((definitionID) => {
+						if(this.allLayouts[definitionID] !== void 0) {
+							available[definitionID] = this.allLayouts[definitionID];
+						}
+					}, this);
+					return available;
+				}
+				else {
+					return this.allLayouts;
+				}
+			}
+			else {
+				return [];
+			}
+		},
 
 		disableSubmit() {
 			return this.createForm.layout === ''	 ||

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -523,6 +523,29 @@ const getters = {
 	},
 
 	/**
+	 * Get the siteDefinitionId for the current site's definition.
+	 * @param state
+	 * @returns {string|null} Site definition ID in the form {name}-v{version} or null if no current site.
+	 */
+	siteDefinitionId: (state) => {
+		return (state.loaded) ?
+				(state.pageData.site.site_definition_name + '-v' + state.pageData.site.site_definition_version) :
+				null;
+	},
+
+	/**
+	 * Get the site definition for the current site.
+	 * @param state
+	 * @param getters
+	 * @param rootState
+	 * @returns {SiteDefinition|null} - The site definition for the current site, or null.
+	 */
+	siteDefinition: (state, getters, rootState) => {
+		const id = getters.siteDefinitionId;
+		return rootState.site.siteDefinitions[id] !== void 0 ? rootState.site.siteDefinitions[id] : null;
+	},
+
+	/**
 	 * Get the data representing the current page.
 	 * @param state
 	 * @returns {state/page.pageData|{blocks}|pageData|Object|*}


### PR DESCRIPTION
This feature restricts the list of available layouts when creating a new page in the editor.

It restricts them to those which are listed in the site's definition availableLayouts array.

If the site definition does not have the availableLayouts attribute, then all layouts will be available.

This PR adds a couple of getters to store/modules/page.js to get the site's definition and adds the layout list filtering code to CreatePageModal.