### PR TITLE
Quick fixes for a couple of bits that slipped by in the last PR.

### DIFF
--- a/resources/assets/js/classes/helpers.js
+++ b/resources/assets/js/classes/helpers.js
@@ -154,6 +154,8 @@ export const prettyDate = (date) => {
 };
 
 export const notify = ({ title, message, type }) => {
+	// TODO:is notify is overkill for some scenarios?
+	// Element UI's $message seems more suited to success messages
 	vue.$notify({
 		title,
 		message,
@@ -163,11 +165,6 @@ export const notify = ({ title, message, type }) => {
 			this.close();
 		}
 	});
-	// vue.$message({
-	// 	message,
-	// 	type,
-	// 	duration: readingSpeedFromString(message, 3000),
-	// });
 };
 
 // Does the given string start with a vowel? If so return "an", otherwise "a".

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -57,7 +57,7 @@ Note that the page editing toolbar is a separate component found in `components/
 				v-if="(!showBack && this.$route.name !== 'site-list') && sites.length === 1"
 				 class="site-pick"
 			>
-				<icon name="site" /> Site 1
+				<icon name="site" /> {{ siteTitle }}
 			</div>
 
 			<div v-show="showBack" @click="backToAdmin" class="top-bar-backbutton">

--- a/resources/assets/js/views/MenuEditor.vue
+++ b/resources/assets/js/views/MenuEditor.vue
@@ -47,7 +47,6 @@
 							:index="index"
 							itemKey="text"
 							name="Link text"
-							placeholder="Homepage"
 							:errors="errors"
 							:validate="validateMenuItem"
 						/>
@@ -56,8 +55,7 @@
 							:item="item"
 							:index="index"
 							itemKey="url"
-							name="Location"
-							placeholder="https://kent.ac.uk"
+							name="URL"
 							:errors="errors"
 							:validate="validateMenuItem"
 						/>


### PR DESCRIPTION
We were trying to merge everything in before the end of the day but jumped the gun before I'd updated the PR :D

TopBar now displays the site title correctly, even if there is only one site available to a user.
Two very minor changes to placeholders in the menu editor component and replaced a commented out bit of code in helpers with a more helpful TODO.