### PR TITLE
Feature/disable forms in editor preview

### DIFF
--- a/resources/assets/js/classes/helpers.js
+++ b/resources/assets/js/classes/helpers.js
@@ -197,3 +197,22 @@ export const getDraftPreviewURL = (url) => {
 export const getPublishedPreviewURL = (url) => {
 	return `${Config.get('base_url', '')}/published/${url ? url.replace(/\/$/, '') : ''}`;
 };
+
+/**
+* prevents users from submitting forms in el
+* while still allowing the user to interact with them
+*/
+export const disableForms = (el) => {
+	// disable buttons
+	const buttonElements = el.querySelectorAll('button, submit');
+	buttonElements.forEach((buttonElement) => {
+		buttonElement.setAttribute('disabled', '');
+	});
+
+	// remove any form actions and methods
+	const formElements = el.querySelectorAll('form');
+	formElements.forEach((formElement) => {
+		formElement.removeAttribute('action');
+		formElement.removeAttribute('method');
+	});
+}

--- a/resources/assets/js/components/BaseLayout.js
+++ b/resources/assets/js/components/BaseLayout.js
@@ -1,0 +1,18 @@
+/**
+base component for the them's layout components
+used as a place to house any functionality requred across all the theme layouts
+**/
+import Region from 'components/Region';
+import { disableForms } from 'classes/helpers';
+
+export default {
+	components: {
+		Region
+	},
+
+	mounted() {
+		// disable any form actions/buttons contained in the layout
+		disableForms(this.$el);
+	}
+};
+

--- a/resources/assets/js/components/Block.vue
+++ b/resources/assets/js/components/Block.vue
@@ -27,6 +27,7 @@
 import blocks from 'cms-prototype-blocks';
 import { mapState, mapGetters, mapMutations } from 'vuex';
 import imagesLoaded from 'imagesloaded';
+import { disableForms } from 'classes/helpers';
 
 export default {
 
@@ -148,7 +149,7 @@ export default {
 			});
 		});
 
-		this.disableForms();
+		disableForms(this.$el);
 	},
 
 
@@ -186,25 +187,6 @@ export default {
 			) {
 				this.$bus.$emit('block:hideOverlay', this);
 			}
-		},
-
-		/**
-		* prevents users from submitting forms in the previewed block
-		* while still allowing the user to interact with previewed forms
-		*/
-		disableForms() {
-			// disable buttons
-			const buttonElements = this.$el.querySelectorAll('button, submit');
-			buttonElements.forEach((buttonElement) => {
-				buttonElement.setAttribute('disabled', '');
-			});
-
-			// remove any form actions and methods
-			const formElements = this.$el.querySelectorAll('form');
-			formElements.forEach((formElement) => {
-				formElement.removeAttribute('action');
-				formElement.removeAttribute('method');
-			});
 		}
 	}
 };

--- a/resources/assets/js/components/Block.vue
+++ b/resources/assets/js/components/Block.vue
@@ -147,6 +147,8 @@ export default {
 				value: this.size.height
 			});
 		});
+
+		this.disableForms();
 	},
 
 
@@ -185,6 +187,25 @@ export default {
 				this.$bus.$emit('block:hideOverlay', this);
 			}
 		},
+
+		/**
+		* prevents users from submitting forms in the previewed block
+		* while still allowing the user to interact with previewed forms
+		*/
+		disableForms() {
+			// disable buttons
+			const buttonElements = this.$el.querySelectorAll('button');
+			buttonElements.forEach((buttonElement) => {
+				buttonElement.setAttribute('disabled', '');
+			});
+
+			// remove any form actions and methods
+			const formElements = this.$el.querySelectorAll('form');
+			formElements.forEach((formElement) => {
+				formElement.removeAttribute('action');
+				formElement.removeAttribute('method');
+			});
+		}
 	}
 };
 </script>

--- a/resources/assets/js/components/Block.vue
+++ b/resources/assets/js/components/Block.vue
@@ -194,7 +194,7 @@ export default {
 		*/
 		disableForms() {
 			// disable buttons
-			const buttonElements = this.$el.querySelectorAll('button');
+			const buttonElements = this.$el.querySelectorAll('button, submit');
 			buttonElements.forEach((buttonElement) => {
 				buttonElement.setAttribute('disabled', '');
 			});


### PR DESCRIPTION
for https://github.com/unikent/astro/issues/198

This disables any buttons and actions within a form in a block within the Astro editor preview iframe.
Inputs are still enabled so users can interact with the forms to see how they work/look but I'm happy to also disable those if needed. 