### PR TITLE
Fix a bug where the paths in the page listing weren't set correctly.

### DIFF
--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -157,12 +157,16 @@ const mutations = {
 		const page = findPageById(state.pages, id);
 
 		if(page) {
-			page.slug = slug;
-
-			updatePaths(
-				page,
-				page.path.substr(0, page.path.lastIndexOf(page.slug)) + slug
+			// get the parent's path before setting the slug
+			// as the old slug is used for substr
+			const parentPath = page.path.substr(
+				0,
+				page.path.lastIndexOf(page.slug)
 			);
+
+			updatePaths(page, parentPath + slug);
+
+			page.slug = slug;
 		}
 	},
 


### PR DESCRIPTION
This was due to the slug being set before it should have been (the previous slug was needed first to grab the parent's path).