### PR TITLE
Validate page layout when the editor is loaded

### DIFF
--- a/resources/assets/js/components/PageListItem.vue
+++ b/resources/assets/js/components/PageListItem.vue
@@ -46,13 +46,14 @@
 				<el-dropdown-item
 					command="openEditModal"
 					v-if="canUser('page.edit')"
+					:disabled="pageHasLayoutErrors"
 				>
 					Edit page settings
 				</el-dropdown-item>
 
 				<el-dropdown-item
 					v-show="!root"
-					:disabled="depth > 2"
+					:disabled="depth > 2 || pageHasLayoutErrors"
 					command="openModal"
 					v-if="canUser('page.add')"
 				>
@@ -63,7 +64,7 @@
 				<el-dropdown-item
 					command="publish"
 					v-if="canUser('page.publish')"
-					:disabled="page.status === 'published' || parentStatus === 'new'"
+					:disabled="page.status === 'published' || parentStatus === 'new' || pageHasLayoutErrors"
 				>
 					Publish
 				</el-dropdown-item>
@@ -177,7 +178,8 @@ export default {
 		}),
 
 		...mapState({
-			pageData: state => state.page.pageData
+			pageData: state => state.page.pageData,
+			layoutErrors: state => state.page.layoutErrors
 		}),
 
 		...mapGetters([
@@ -204,6 +206,13 @@ export default {
 			},
 			// don't set directly (use vuex instead)
 			set() {}
+		},
+
+		/**
+		 * Determines if the page this list item represents is being edited and has layout errors.
+		 */
+		pageHasLayoutErrors() {
+			return this.pageData.id === this.page.id && this.layoutErrors.length !== 0;
 		}
 	},
 

--- a/resources/assets/js/components/ResizeShim.vue
+++ b/resources/assets/js/components/ResizeShim.vue
@@ -30,11 +30,15 @@ export default {
 	},
 
 	mounted() {
-		this.$refs['hidden-frame'].contentWindow.addEventListener('resize', this.onResize, false);
+		if (this.$refs['hidden-frame'].contentWindow) {
+			this.$refs['hidden-frame'].contentWindow.addEventListener('resize', this.onResize, false);
+		}
 	},
 
 	beforeDestroy() {
-		this.$refs['hidden-frame'].contentWindow.removeEventListener('resize', this.onResize);
+		if (this.$refs['hidden-frame'].contentWindow) {
+			this.$refs['hidden-frame'].contentWindow.removeEventListener('resize', this.onResize);
+		}
 	}
 };
 </script>

--- a/resources/assets/js/components/ResizeShim.vue
+++ b/resources/assets/js/components/ResizeShim.vue
@@ -30,9 +30,7 @@ export default {
 	},
 
 	mounted() {
-		if (this.$refs['hidden-frame'].contentWindow) {
-			this.$refs['hidden-frame'].contentWindow.addEventListener('resize', this.onResize, false);
-		}
+		this.$refs['hidden-frame'].contentWindow.addEventListener('resize', this.onResize, false);
 	},
 
 	beforeDestroy() {

--- a/resources/assets/js/components/Toolbar.vue
+++ b/resources/assets/js/components/Toolbar.vue
@@ -2,7 +2,12 @@
 <div class="toolbar">
 
 	<el-tooltip v-if="canUser('page.edit')" class="item" effect="dark" content="Switch edit mode" placement="top">
-		<el-select placeholder="view" v-model="view" class="switch-view">
+		<el-select 
+			placeholder="view" 
+			v-model="view" 
+			class="switch-view"
+			:disabled="pageHasLayoutErrors ? true : false"
+		>
 			<el-option v-for="(view, key) in views" :label="view.label" :value="key" :key="view.label">
 				<div class="view-icon">
 					<icon :name="view.icon" aria-hidden="true" width="20" height="20" />
@@ -12,9 +17,22 @@
 		</el-select>
 	</el-tooltip>
 
-	<el-button v-if="canUser('page.edit')" class="toolbar__button-save" type="primary" @click="savePage" v-loading.fullscreen.lock="fullscreenLoading">Save</el-button>
+	<el-button 
+		v-if="canUser('page.edit')" 
+		class="toolbar__button-save" 
+		type="primary" 
+		@click="savePage" 
+		v-loading.fullscreen.lock="fullscreenLoading"
+		:disabled="pageHasLayoutErrors ? true : false"
+	>Save</el-button>
 
-	<el-button v-if="canUser('page.preview')" class="toolbar__button-preview" plain @click="previewPage">Preview <icon name="newwindow" aria-hidden="true" width="14" height="14" class="ico" /></el-button>
+	<el-button 
+		v-if="canUser('page.preview')" 
+		class="toolbar__button-preview" 
+		plain 
+		@click="previewPage"
+		:disabled="pageHasLayoutErrors ? true : false"
+	>Preview <icon name="newwindow" aria-hidden="true" width="14" height="14" class="ico" /></el-button>
 
 	<template v-if="canUser('page.publish')">
 		<el-button
@@ -22,6 +40,7 @@
 			v-if="invalidBlocks"
 			type="success"
 			@click="publishPage"
+			:disabled="pageHasLayoutErrors ? true : false"
 		>Publish...</el-button>
 		<el-button
 			class="toolbar__button-publish"
@@ -66,7 +85,8 @@ export default {
 
 		...mapState({
 			page: state => state.page.pageData,
-			pageLoaded: state => state.page.loaded
+			pageLoaded: state => state.page.loaded,
+			layoutErrors: state => state.page.layoutErrors
 		}),
 
 		...mapGetters([
@@ -90,6 +110,10 @@ export default {
 
 		invalidBlocks() {
 			return this.getInvalidBlocks().length === 0 ? true : false;
+		},
+
+		pageHasLayoutErrors() {
+			return this.layoutErrors.length !== 0;
 		}
 	},
 

--- a/resources/assets/js/components/Toolbar.vue
+++ b/resources/assets/js/components/Toolbar.vue
@@ -6,7 +6,7 @@
 			placeholder="view" 
 			v-model="view" 
 			class="switch-view"
-			:disabled="pageHasLayoutErrors ? true : false"
+			:disabled="pageHasLayoutErrors"
 		>
 			<el-option v-for="(view, key) in views" :label="view.label" :value="key" :key="view.label">
 				<div class="view-icon">
@@ -23,7 +23,7 @@
 		type="primary" 
 		@click="savePage" 
 		v-loading.fullscreen.lock="fullscreenLoading"
-		:disabled="pageHasLayoutErrors ? true : false"
+		:disabled="pageHasLayoutErrors"
 	>Save</el-button>
 
 	<el-button 
@@ -31,7 +31,7 @@
 		class="toolbar__button-preview" 
 		plain 
 		@click="previewPage"
-		:disabled="pageHasLayoutErrors ? true : false"
+		:disabled="pageHasLayoutErrors"
 	>Preview <icon name="newwindow" aria-hidden="true" width="14" height="14" class="ico" /></el-button>
 
 	<template v-if="canUser('page.publish')">
@@ -40,13 +40,14 @@
 			v-if="invalidBlocks"
 			type="success"
 			@click="publishPage"
-			:disabled="pageHasLayoutErrors ? true : false"
+			:disabled="pageHasLayoutErrors"
 		>Publish...</el-button>
 		<el-button
 			class="toolbar__button-publish"
 			v-else
 			type="success"
 			@click="showPublishValidationWarningModal"
+			:disabled="pageHasLayoutErrors"
 		>Publish...</el-button>
 	</template>
 

--- a/resources/assets/js/components/TopBar.vue
+++ b/resources/assets/js/components/TopBar.vue
@@ -77,7 +77,8 @@ Note that the page editing toolbar is a separate component found in `components/
 					{{ pageTitle }}
 					<el-tag type="warning">Draft</el-tag>
 				</div>
-				<span class="top-bar__url"><a :href="draftPreviewURL" target="_blank">{{ renderedURL }}</a> <icon name="newwindow" aria-hidden="true" width="12" height="12" class="ico" /></span>
+				<span v-if="!pageHasLayoutErrors" class="top-bar__url">
+					<a :href="draftPreviewURL" target="_blank">{{ renderedURL }}</a> <icon name="newwindow" aria-hidden="true" width="12" height="12" class="ico" /></span>
 			</div>
 
 			<div v-else-if="showTools && publishStatus === 'published'" class="top-bar__page-title">
@@ -124,7 +125,7 @@ Note that the page editing toolbar is a separate component found in `components/
 </template>
 
 <script>
-	import { mapGetters, mapActions, mapMutations } from 'vuex';
+	import { mapState, mapGetters, mapActions, mapMutations } from 'vuex';
 	import Icon from 'components/Icon';
 	import Toolbar from 'components/Toolbar';
 	import promptToSave from '../mixins/promptToSave';
@@ -183,6 +184,10 @@ Note that the page editing toolbar is a separate component found in `components/
 				'draftPreviewURL'
 			]),
 
+			...mapState({
+				layoutErrors: state => state.page.layoutErrors
+			}),
+
 			// works out if we should show a back button or not (ie whether we're editing a page or on the homepage)
 			showBack() {
 				return ['page'].indexOf(this.$route.name) !== -1;
@@ -209,6 +214,10 @@ Note that the page editing toolbar is a separate component found in `components/
 			siteTitle() {
 				const site = this.sites.find(site => site.id === Number(this.$route.params.site_id));
 				return site ? site.name : '';
+			},
+
+			pageHasLayoutErrors() {
+				return this.layoutErrors.length !== 0;
 			}
 		},
 

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -250,12 +250,12 @@ const actions = {
 	fetchPage({ commit }, id) {
 		commit('setPage', null);
 		// TODO: refactor into smaller methods
-		api
+		return api
 			.get(`pages/${id}?include=blocks.media,site`)
 			.then(response => {
 				const page = response.data.data;
 
-				api
+				return api
 					.get(`layouts/${page.layout.name}-v${page.layout.version}/definition?include=region_definitions.block_definitions`)
 					.then(({ data: region }) => {
 

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -22,6 +22,7 @@ const vue = new Vue();
 const state = {
 	currentLayout: null,
 	currentLayoutVersion: 1,
+	layoutErrors: [],
 	currentBlockIndex: null,
 	currentRegion: null,
 	blockMeta: {
@@ -64,6 +65,10 @@ const mutations = {
 
 	setBlock(state, { index } = { index: null }) {
 		state.currentBlockIndex = index;
+	},
+
+	setLayoutErrors (state, layoutErrors) {
+		state.layoutErrors = layoutErrors;
 	},
 
 	reorderBlocks(state, { from, to, region, section }) {

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -1,5 +1,5 @@
 <template>
-<div>
+<div v-if="layoutErrors.length === 0">
 	<div id="b-wrapper" ref="wrapper" :style="wrapperStyles">
 		<component :is="layout" />
 		<div
@@ -243,32 +243,39 @@ export default {
 
 
 			_.each($this.layoutDefinition.regions, function (regionName) {
-				
-				let regionDefinition = Definition.regionDefinitions[regionName];
 
 				// check that this defined region exist in the page's regions
 				if ($this.pageData.blocks[regionName] === void 0) {
 					$this.layoutErrors.push(`The region '${regionName}' was expected but not found on this page.`);
 				}
+				
+				let regionDefinition = Definition.regionDefinitions[regionName];
 
-				_.each(regionDefinition.sections, function(sectionDefinition, index) {
-					
-					// check that this section is in the right part of the region
-					if ($this.pageData.blocks[regionName][index].name !== sectionDefinition.name) {
-						$this.layoutErrors.push(`The section '${sectionDefinition.name}' was expected, but found '${$this.pageData.blocks[regionName][index].name}'.`);
+				if (regionDefinition !== void 0) {
+					_.each(regionDefinition.sections, function(sectionDefinition, index) {
 						
-					}
+						// check that this section is in the right part of the region
+						if ($this.pageData.blocks[regionName][index].name !== sectionDefinition.name) {
+							$this.layoutErrors.push(`The section '${sectionDefinition.name}' was expected, but found '${$this.pageData.blocks[regionName][index].name}'.`);
+							
+						}
 
-					// if the section is in the right part of the region, go ahead and check that it has the right blocks within it
-					else {
-						_.each($this.pageData.blocks[regionName][index].blocks, function (block) {
-							let fullBlockName = block.definition_name + '-v' + block.definition_version;
-							if (sectionDefinition.allowedBlocks.indexOf(fullBlockName) < 0) {
-								$this.layoutErrors.push(`The block '${fullBlockName}' is now allowed in the '${sectionDefinition.name}' section of the '${regionName}' region.`);
-							}
-						});
-					}
-				});
+						// if the section is in the right part of the region, go ahead and check that it has the right blocks within it
+						else {
+							_.each($this.pageData.blocks[regionName][index].blocks, function (block) {
+								let fullBlockName = block.definition_name + '-v' + block.definition_version;
+								if (sectionDefinition.allowedBlocks.indexOf(fullBlockName) < 0) {
+									$this.layoutErrors.push(`The block '${fullBlockName}' is now allowed in the '${sectionDefinition.name}' section of the '${regionName}' region.`);
+								}
+							});
+						}
+					});
+				}
+
+				// the defined region was not loaded in our region definitions
+				else {
+					$this.layoutErrors.push(`The defined region '${regionName}' was not found in our loaded region definitions`);
+				}
 			});
 		},
 

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -304,7 +304,7 @@ export default {
 						// check to see if there are more sections than defined
 						if (this.pageData.blocks[regionDefinitionName].length > regionDefinition.sections.length) {
 							for (var i = regionDefinition.sections.length; i < this.pageData.blocks[regionDefinitionName].length; i++) {
-								layoutErrors.push(`Page contains section '${this.pageData.blocks[regionDefinitionName][i].name}' which is not allowed in region '${regionDefinitionName}' of layout '${layoutName}'.`); 
+								layoutErrors.push(`Page contains an additional section '${this.pageData.blocks[regionDefinitionName][i].name}' at position ${i+1}. ${regionDefinition.sections.length} section(s) were expected in region '${regionDefinitionName}' of layout '${layoutName}'.`); 
 							}
 						}
 

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -273,21 +273,21 @@ export default {
 
 				// we have the region in our data
 				else {
-				
+
 					let regionDefinition = Definition.regionDefinitions[regionDefinitionName];
 
 					if (regionDefinition !== void 0) {
 						regionDefinition.sections.forEach((sectionDefinition, index) => {
-							
+
 							// check that the section is present
 							if (this.pageData.blocks[regionDefinitionName][index] === void 0) {
 								layoutErrors.push(`The section '${sectionDefinition.name}' was expected in '${regionDefinitionName}' region, but found none.`);
 							}
-							
+
 							// check that this section is in the right part of the region
 							else if(this.pageData.blocks[regionDefinitionName][index].name !== sectionDefinition.name) {
 								layoutErrors.push(`The section '${sectionDefinition.name}' was expected in '${regionDefinitionName}' region, but found '${this.pageData.blocks[regionDefinitionName][index].name}'.`);
-								
+
 							}
 
 							// if the section is in the right part of the region, go ahead and check that it has the right blocks within it
@@ -304,7 +304,7 @@ export default {
 						// check to see if there are more sections than defined
 						if (this.pageData.blocks[regionDefinitionName].length > regionDefinition.sections.length) {
 							for (var i = regionDefinition.sections.length; i < this.pageData.blocks[regionDefinitionName].length; i++) {
-								layoutErrors.push(`Page contains an additional section '${this.pageData.blocks[regionDefinitionName][i].name}' at position ${i+1}. ${regionDefinition.sections.length} section(s) were expected in region '${regionDefinitionName}' of layout '${layoutName}'.`); 
+								layoutErrors.push(`Page contains an additional section '${this.pageData.blocks[regionDefinitionName][i].name}' at position ${i+1}. ${regionDefinition.sections.length} section(s) were expected in region '${regionDefinitionName}' of layout '${layoutName}'.`);
 							}
 						}
 

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -251,7 +251,7 @@ export default {
 			this.layoutDefinition = this.siteLayoutDefinitions[layoutName];
 			// check that we have the same number of regions in our data as we have defined
 			if (Object.keys(this.pageData.blocks).length !== this.layoutDefinition.regions.length) {
-				this.layoutErrors.push('The regions on this page do not match the expected regions it should have.');
+				this.layoutErrors.push(`The regions on this page do not match the expected regions it should have in layout '${layoutName}'.`);
 			}
 
 
@@ -259,7 +259,7 @@ export default {
 
 				// check that this defined region exist in the page's regions
 				if (this.pageData.blocks[regionDefinitionName] === void 0) {
-					this.layoutErrors.push(`The region '${regionDefinitionName}' was expected but not found on this page.`);
+					this.layoutErrors.push(`The region '${regionDefinitionName}' was expected but not found on this page. Layout is '${layoutName}'.`);
 				}
 				
 				let regionDefinition = Definition.regionDefinitions[regionDefinitionName];
@@ -287,7 +287,7 @@ export default {
 
 				// the defined region was not loaded in our region definitions
 				else {
-					this.layoutErrors.push(`The defined region '${regionDefinitionName}' was not found in our loaded region definitions`);
+					this.layoutErrors.push(`The defined region '${regionDefinitionName}' was not found in our loaded region definitions.`);
 				}
 			});
 

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -122,7 +122,8 @@ export default {
 			current: null,
 			sectionDefinition: null,
 			sectionConstraints: null,
-			currentSectionBlocks: null
+			currentSectionBlocks: null,
+			layoutDefinition: null
 		};
 	},
 
@@ -136,7 +137,8 @@ export default {
 			currentLayout: state => state.page.currentLayout,
 			currentRegion: state => state.contenteditor.currentRegionName,
 			layoutVersion: state => state.page.currentLayoutVersion,
-			blockMeta: state => state.page.blockMeta.blocks[state.page.currentRegion]
+			blockMeta: state => state.page.blockMeta.blocks[state.page.currentRegion],
+			siteLayoutDefinitions: state => state.site.layouts
 		}),
 
 		...mapGetters([
@@ -174,7 +176,14 @@ export default {
 	},
 
 	created() {
-		this.fetchPage(this.$route.params.page_id || 1);
+		var $this = this;
+		this.fetchPage(this.$route.params.page_id || 1)// is this fallback necessary?
+			.then(function () {
+				//fire off a funtion to validate the regions, section and blocks in the current page's layout.
+				$this.layoutDefinition = $this.siteLayoutDefinitions[`${$this.currentLayout}-v${$this.layoutVersion}`]
+				console.log('page fetched!!!', $this.layoutDefinition);
+				//$this.layoutDefinition now has the layout we're interested in, we can use it to do the validation
+			});
 
 		this.onKeyDown = onKeyDown(undoStackInstance);
 		this.onKeyUp = onKeyUp(undoStackInstance);

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -270,33 +270,51 @@ export default {
 				if (this.pageData.blocks[regionDefinitionName] === void 0) {
 					layoutErrors.push(`The region '${regionDefinitionName}' was expected but not found on this page. Layout is '${layoutName}'.`);
 				}
-				
-				let regionDefinition = Definition.regionDefinitions[regionDefinitionName];
 
-				if (regionDefinition !== void 0) {
-					regionDefinition.sections.forEach((sectionDefinition, index) => {
-						
-						// check that this section is in the right part of the region
-						if (this.pageData.blocks[regionDefinitionName][index].name !== sectionDefinition.name) {
-							layoutErrors.push(`The section '${sectionDefinition.name}' was expected in '${regionDefinitionName}' region, but found '${this.pageData.blocks[regionDefinitionName][index].name}'.`);
-							
-						}
-
-						// if the section is in the right part of the region, go ahead and check that it has the right blocks within it
-						else {
-							this.pageData.blocks[regionDefinitionName][index].blocks.forEach((block) => {
-								let fullBlockName = block.definition_name + '-v' + block.definition_version;
-								if (sectionDefinition.allowedBlocks.indexOf(fullBlockName) < 0) {
-									layoutErrors.push(`The block '${fullBlockName}' is not allowed in the '${sectionDefinition.name}' section of the '${regionDefinitionName}' region.`);
-								}
-							});
-						}
-					});
-				}
-
-				// the defined region was not loaded in our region definitions
+				// we have the region in our data
 				else {
-					layoutErrors.push(`The defined region '${regionDefinitionName}' was not found in our loaded region definitions.`);
+				
+					let regionDefinition = Definition.regionDefinitions[regionDefinitionName];
+
+					if (regionDefinition !== void 0) {
+						regionDefinition.sections.forEach((sectionDefinition, index) => {
+							
+							// check that the section is present
+							if (this.pageData.blocks[regionDefinitionName][index] === void 0) {
+								layoutErrors.push(`The section '${sectionDefinition.name}' was expected in '${regionDefinitionName}' region, but found none.`);
+							}
+							
+							// check that this section is in the right part of the region
+							else if(this.pageData.blocks[regionDefinitionName][index].name !== sectionDefinition.name) {
+								layoutErrors.push(`The section '${sectionDefinition.name}' was expected in '${regionDefinitionName}' region, but found '${this.pageData.blocks[regionDefinitionName][index].name}'.`);
+								
+							}
+
+							// if the section is in the right part of the region, go ahead and check that it has the right blocks within it
+							else {
+								this.pageData.blocks[regionDefinitionName][index].blocks.forEach((block) => {
+									let fullBlockName = block.definition_name + '-v' + block.definition_version;
+									if (sectionDefinition.allowedBlocks.indexOf(fullBlockName) < 0) {
+										layoutErrors.push(`The block '${fullBlockName}' is not allowed in the '${sectionDefinition.name}' section of the '${regionDefinitionName}' region.`);
+									}
+								});
+							}
+						});
+
+						// check to see if there are more sections than defined
+						if (this.pageData.blocks[regionDefinitionName].length > regionDefinition.sections.length) {
+							for (var i = regionDefinition.sections.length; i < this.pageData.blocks[regionDefinitionName].length; i++) {
+								layoutErrors.push(`Page contains section '${this.pageData.blocks[regionDefinitionName][i].name}' which is not allowed in region '${regionDefinitionName}' of layout '${layoutName}'.`); 
+							}
+						}
+
+					}
+
+					// the defined region was not loaded in our region definitions
+					else {
+						layoutErrors.push(`The defined region '${regionDefinitionName}' was not found in our loaded region definitions.`);
+					}
+
 				}
 			});
 

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -268,7 +268,7 @@ export default {
 						
 						// check that this section is in the right part of the region
 						if ($this.pageData.blocks[regionName][index].name !== sectionDefinition.name) {
-							$this.layoutErrors.push(`The section '${sectionDefinition.name}' was expected, but found '${$this.pageData.blocks[regionName][index].name}'.`);
+							$this.layoutErrors.push(`The section '${sectionDefinition.name}' was expected in '${regionName}' region, but found '${$this.pageData.blocks[regionName][index].name}'.`);
 							
 						}
 

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -79,6 +79,18 @@
 	<div id="b-overlay" :style="overlayStyles"></div>
 	<resize-shim :onResize="onResize" />
 </div>
+<el-card v-else class="box-card error-card">
+	<div slot="header" class="clearfix">
+		<i class="error-icon el-icon-error is-big"></i>
+		<span class="error-title is-bold">A layout error occured</span>
+	</div>
+	<p>Please report the following errors to your administrator</p>
+	<ul>
+		<li v-for="layoutError in layoutErrors" class="text item">
+			{{ layoutError }}
+		</li>
+	</ul>
+</el-card>
 </template>
 
 <script>

--- a/resources/assets/js/views/Preview.vue
+++ b/resources/assets/js/views/Preview.vue
@@ -90,6 +90,7 @@
 			{{ layoutError }}
 		</li>
 	</ul>
+	<p>The current page's path is: <strong>/site/{{ siteId }}/page/{{ $route.params.page_id }}</strong>.</p>
 </el-card>
 </template>
 
@@ -152,7 +153,8 @@ export default {
 			currentRegion: state => state.contenteditor.currentRegionName,
 			layoutVersion: state => state.page.currentLayoutVersion,
 			blockMeta: state => state.page.blockMeta.blocks[state.page.currentRegion],
-			siteLayoutDefinitions: state => state.site.layouts
+			siteLayoutDefinitions: state => state.site.layouts,
+			siteId: state => parseInt(state.site.site)
 		}),
 
 		...mapGetters([

--- a/resources/assets/sass/_element-ui.scss
+++ b/resources/assets/sass/_element-ui.scss
@@ -223,6 +223,25 @@
 	}
 }
 
+// error cards
+.box-card.error-card {
+	background-color: #fee;
+	
+	.el-card__header {
+    	color: #fa5555;
+    	font-size: 2rem;
+
+    	.clearfix {
+    		align-items: center;
+			display: flex;
+    	}
+
+    	.error-title {
+    		padding: 0 0.5rem;
+    	}
+	}
+}
+
 @each $status, $colour in $status-colours {
 	.el-button--#{$status} {
 		@include button-variant($colour);


### PR DESCRIPTION
This validates a page's layout by ensuring it has the correct regions, sections and blocks. If there is an issue with the page, its blocks will not be rendered, and an error is showns.

Fixes: https://github.com/unikent/astro/issues/168