### PR TITLE
Baking pages includes all sections and regions for the page layout. 

### DIFF
--- a/app/Models/APICommands/AddsPagesTrait.php
+++ b/app/Models/APICommands/AddsPagesTrait.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Models\Definitions\Layout;
 use App\Models\Page;
 use App\Models\Revision;
 use App\Models\RevisionSet;
@@ -44,7 +45,7 @@ trait AddsPagesTrait
 			'updated_by' => $user->id,
 			'layout_name' => $layout_name,
 			'layout_version' => $layout_version,
-			'blocks' => $page->bake(),
+			'blocks' => $page->bake(Layout::idFromNameAndVersion($layout_name, $layout_version)),
 			'options' => null,
 			'valid' => true
 		]);

--- a/app/Models/APICommands/UpdateContent.php
+++ b/app/Models/APICommands/UpdateContent.php
@@ -3,6 +3,7 @@
 namespace App\Models\APICommands;
 
 use App\Models\Contracts\APICommand;
+use App\Models\Definitions\Layout;
 use App\Models\Definitions\Region;
 use App\Models\Revision;
 use App\Models\Block;
@@ -43,7 +44,7 @@ class UpdateContent implements APICommand
 				'layout_version' => $previous_revision->layout_version,
 				'created_by' => $user->id,
 				'updated_by' => $user->id,
-				'blocks' => $page->bake(),
+				'blocks' => $page->bake(Layout::idFromNameAndVersion($previous_revision->layout_name, $previous_revision->layout_version)),
 				'options' => '',
 				'valid' => !$errors
 			]);

--- a/app/Models/Definitions/Layout.php
+++ b/app/Models/Definitions/Layout.php
@@ -34,6 +34,20 @@ class Layout extends BaseDefinition
 	}
 
 	/**
+	 * Get the data structure that defines the regions and sections for a page using this layout.
+	 * @return array Array of [region-name => [section1, ...], ... ]
+	 */
+	public function getDataStructure()
+	{
+		$data = [];
+		foreach($this->getRegionDefinitions() as $region_definition){
+			$region_id = Region::idFromNameAndVersion($region_definition->name, $region_definition->version);
+			$data[$region_id] = $region_definition->getDataStructure();
+		}
+		return $data;
+	}
+
+	/**
 	 * Get the default page content (regions, sections and blocks) for this layout.
 	 * @return array - [ region-name => [ [ 'name' => 'section-1-name', 'blocks' => [ ... block data ... ], ... ] ], ... ]
 	 */

--- a/app/Models/Definitions/Region.php
+++ b/app/Models/Definitions/Region.php
@@ -38,6 +38,22 @@ class Region extends BaseDefinition
 	}
 
 	/**
+	 * Get the data structure that defines the sections for this region.
+	 * @return array Array of [ ['name' => 'section-name', 'blocks' => [] ], ... ]
+	 */
+	public function getDataStructure()
+	{
+		$sections = [];
+		foreach($this->sections as $section) {
+			$sections[] = [
+				'name' => $section['name'],
+				'blocks' => []
+			];
+		}
+		return $sections;
+	}
+
+	/**
 	 * Returns the blockDefinitions Collection, populating it from disk if necessary.
 	 *
 	 * @return Collection


### PR DESCRIPTION
Fixes #212

Baking pages worked by creating the page data structure from the blocks in the database for that page.

This meant that any optional sections with no blocks currently configured would not be present in the baked data.

This fix first creates an empty (blockless) page data structure containing all regions and sections for the page's layout and then adds all the blocks from the database for the page to this structure.