### PR TITLE
Log and notify user of block errors on page load.

### DIFF
--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -281,20 +281,14 @@ const actions = {
 								page.blocks[region][sindex].blocks.forEach((block) => {
 									Definition.fillBlockFields(block);
 									blockMeta.blocks[region][sindex].blocks.push({ size: 0, offset: 0 });
+									if( typeof block.errors !== void 0 && block.errors !== null) {
+										commit('addBlockValidationIssue', block.id);
+									}
 								});
 							});
 						});
 
 						commit('addBlockMeta', blockMeta);
-
-						// Object.keys(blocks).forEach(region => {
-						// 	blocks[region].forEach((block) => {
-						// 		if (typeof block.errors !== 'undefined' && block.errors !== null) {
-						// 			commit('addBlockValidationIssue', block.id);
-						// 		}
-						// 	});
-						// });
-						// TODO: populate validations issues with those received from the api
 						commit('setLoaded');
 					});
 


### PR DESCRIPTION
Fixes #213 

In the site editor, the UI doesn't display validation errors in blocks when a page has been loaded. And so when you try to save the page, it tells you there are errors but gives no indication of where it is.

This fix restores previously existing functionality which was probably disabled when adding sections.