### PR TITLE
Do not disable buttons in editor if they have class el-button

### DIFF
--- a/resources/assets/js/classes/helpers.js
+++ b/resources/assets/js/classes/helpers.js
@@ -206,7 +206,9 @@ export const disableForms = (el) => {
 	// disable buttons
 	const buttonElements = el.querySelectorAll('button, submit');
 	buttonElements.forEach((buttonElement) => {
-		buttonElement.setAttribute('disabled', '');
+		if(!buttonElement.classList.contains('el-button')) {
+			buttonElement.setAttribute('disabled', '');
+		}
 	});
 
 	// remove any form actions and methods


### PR DESCRIPTION
Fixes #198 regression for now.

Disabling all buttons and forms in layouts had the side-effect that our empty section
component's add block button was also disabled.