### PR TITLE
CreatePageModal generates slug automatically from page title unless user edits slug.

### DIFF
--- a/resources/assets/js/components/CreatePageModal.vue
+++ b/resources/assets/js/components/CreatePageModal.vue
@@ -2,7 +2,7 @@
 <el-dialog title="Create Page" :visible.sync="visible" :modal-append-to-body="false">
 	<el-form :model="createForm">
 		<el-form-item label="Page title">
-			<el-input name="title" v-model="createForm.title" auto-complete="off"></el-input>
+			<el-input name="title" v-model="title" auto-complete="off"></el-input>
 		</el-form-item>
 		<el-form-item label="Layout">
 			<el-select
@@ -23,9 +23,8 @@
 		<el-form-item label="slug">
 			<el-input
 				name="slug"
-				v-model="createForm.route.slug"
-				v-bind:placeholder="suggestedSlug"
-				auto-complete="off" @focus="setUserEditingSlug"></el-input>
+				v-model="createForm.slug"
+				auto-complete="off" @change="setUserEditingSlug"></el-input>
 		</el-form-item>
 	</el-form>
 	<span slot="footer" class="dialog-footer">
@@ -46,17 +45,13 @@ export default {
 
 	data() {
 		return {
+			userEditingSlug: false,
 			createForm: {
-				title: 'New page',
+				title: 'New Page',
 				layout: '',
-				route: {
-					slug: '',
-					parent_id: 1
-				},
-				blocks: {},
-				options: {}
-			},
-			userEditingSlug: false
+				slug: 'new-page',
+				parent_id: null,
+			}
 		};
 	},
 
@@ -70,6 +65,18 @@ export default {
 		...mapGetters([
 			'siteDefinition'
 		]),
+
+		title: {
+			set(val) {
+				this.createForm.title = val;
+				if(!this.userEditingSlug) {
+					this.createForm.slug = this.suggestedSlug;
+				}
+			},
+			get() {
+				return this.createForm.title;
+			}
+		},
 
 		layouts() {
 			if(this.siteDefinition){
@@ -94,13 +101,13 @@ export default {
 		disableSubmit() {
 			return this.createForm.layout === ''	 ||
 				this.createForm.title === '' ||
-				this.createForm.route.slug === '';
+				this.createForm.slug === '';
 		},
 
 		visible: {
 			get() {
 				/* eslint-disable camelcase */
-				this.createForm.route.parent_id = this.pageModal.parentId;
+				this.createForm.parent_id = this.pageModal.parentId;
 				/* eslint-enable camelcase */
 				return this.pageModal.visible;
 			},
@@ -128,10 +135,6 @@ export default {
 		}),
 
 		addChild() {
-			// if the user has not edited the slug then use the suggested slug
-			if(!this.userEditingSlug) {
-				this.createForm.route.slug = this.suggestedSlug;
-			}
 			this.createPage({
 				...this.createForm,
 				layout: {
@@ -144,22 +147,16 @@ export default {
 		},
 
 		setUserEditingSlug() {
-			if (this.userEditingSlug ===  false) {
-				this.userEditingSlug = true;
-				this.createForm.route.slug = this.suggestedSlug;
-			}
+			this.userEditingSlug = true;
 		},
 
 		resetForm() {
+			this.userEditingSlug = false;
 			this.createForm = {
 				title: 'New page',
 				layout: '',
-				route: {
-					slug: '',
-					parent_id: 1
-				},
-				blocks: {},
-				options: {}
+				slug: 'new-page',
+				parent_id: null
 			}
 		}
 	}

--- a/resources/assets/js/store/modules/site.js
+++ b/resources/assets/js/store/modules/site.js
@@ -248,9 +248,9 @@ const actions = {
 		api
 			.post('pages', {
 				/* eslint-disable camelcase */
-				parent_id: page.route.parent_id,
+				parent_id: page.parent_id,
 				/* eslint-enable camelcase */
-				slug: page.route.slug,
+				slug: page.slug,
 				layout: {
 					name: page.layout.name,
 					version: page.layout.version,


### PR DESCRIPTION
Fixes #227 by using a computed property for the page title in the CreatePageModal with a setter
that checks if the user has manually edited the slug and if not sets the slug to the slugified title.

The slug input now reacts to the change event instead of the focus event to determine whether or not
the user has started editing it manually.

Also minor refactor on the createForm data model to make it saner.