### PR TITLE
fix DefinitionBroker inheritance

### DIFF
--- a/app/Validation/Brokers/DefinitionBroker.php
+++ b/app/Validation/Brokers/DefinitionBroker.php
@@ -2,8 +2,7 @@
 namespace App\Validation\Brokers;
 
 use Illuminate\Validation\ValidationException;
-use App\Models\Definitions\Block as BlockDefinition;
-use App\Models\Definition\BaseDefinition as Definition;
+use App\Models\Definitions\BaseDefinition as BaseDefinition;
 use Illuminate\Validation\Validator as LaravelValidator;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
@@ -13,7 +12,7 @@ abstract class DefinitionBroker {
 	protected $definition;
 
 
-	public function __construct(BlockDefinition $definition)
+	public function __construct(BaseDefinition $definition)
 	{
 		$this->definition = $definition;
 	}

--- a/app/Validation/Brokers/RegionBroker.php
+++ b/app/Validation/Brokers/RegionBroker.php
@@ -6,11 +6,6 @@ use App\Models\Definitions\Region as RegionDefinition;
 class RegionBroker extends DefinitionBroker
 {
 
-	public function __construct(RegionDefinition $definition)
-	{
-		$this->definition = $definition;
-	}
-
 	/**
 	 * Creates an array of validation rules based on Section block-constraints
 	 * NOTE: this return value is not a ruleset but an array of rules to be assembled into 


### PR DESCRIPTION
Let DefinitionBroker extend BaseDefinition, so that RegionBroker can use the same constructor.

See https://github.com/unikent/astro/issues/169