### PR TITLE
Restrict Media Picker and Media Library to items in the current site …

### DIFF
--- a/resources/assets/js/components/MediaPicker.vue
+++ b/resources/assets/js/components/MediaPicker.vue
@@ -67,7 +67,8 @@ export default {
 		...mapState({
 			mediaPicker: state => state.media.mediaPicker,
 			currentBlockIndex: state => state.contenteditor.currentBlockIndex,
-			currentRegionName: state => state.contenteditor.currentRegionName
+			currentRegionName: state => state.contenteditor.currentRegionName,
+			siteId: state => state.site.site
 		}),
 
 		...mapGetters([
@@ -143,7 +144,7 @@ export default {
 		fetchMedia() {
 			this.$api
 				// TODO: if unmodified since
-				.get('media?order=id.desc', {})
+				.get(`media?order=id.desc&site_ids[]=${this.siteId}`)
 				.then(({ headers, data: json }) => {
 					this.lastUpdated = headers.date;
 					this.media = json.data;

--- a/resources/assets/js/views/Media.vue
+++ b/resources/assets/js/views/Media.vue
@@ -102,7 +102,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 
 import Results from 'components/media/Results';
 import MediaUpload from 'components/MediaUpload';
@@ -135,6 +135,10 @@ export default {
 	},
 
 	computed: {
+		...mapState({
+			siteId: state => state.site.site
+		}),
+
 		colCount() {
 			switch(this.imageSize) {
 				case 0:
@@ -183,7 +187,7 @@ export default {
 
 		fetchMedia() {
 			this.$api
-				.get('media?order=id.desc')
+				.get(`media?order=id.desc&site_ids[]=${this.siteId}`)
 				.then(({ data: json }) => {
 					this.images = json.data;
 				});


### PR DESCRIPTION
…rather than all items

This PR limits the media items shown in the media picker and the site's media manager to only show items belonging to the current site. 

This bug existed because previously all media items were global across all sites. (aka Jack forgot)