### PR TITLE
Make sure the media controller performs the correct permission checks

### DIFF
--- a/app/Http/Controllers/Api/v1/MediaController.php
+++ b/app/Http/Controllers/Api/v1/MediaController.php
@@ -20,7 +20,7 @@ class MediaController extends ApiController
 	 * GET /api/v1/media
 	 *
 	 * Returns an index of Media objects.
-	 * Supports querying with site_ids, pubishing_group_ids, types and mime_types.
+	 * Supports querying with site_ids, types and mime_types.
 	 *
 	 * @param  Request $request
 	 * @return Response
@@ -29,12 +29,13 @@ class MediaController extends ApiController
 		$query = Media::query();
 
 		if(!$request->has('site_ids')){
+			// this doesn't occur currently and always throws an auth exception
 			$this->authorize('index', Media::class);
-		}
-
-		if($request->has('site_ids')){
+		} else {
 			$sites = Site::whereIn('id', $request->get('site_ids'))->get();
 
+			// TODO: think about allowing user to view some results if
+			// they have access to one of the sites requested
 			foreach($sites as $site){
 				$this->authorize('index', [ Media::class, $site ]);
 			}

--- a/app/Http/Controllers/Api/v1/MediaController.php
+++ b/app/Http/Controllers/Api/v1/MediaController.php
@@ -87,13 +87,14 @@ class MediaController extends ApiController
 			$media->sites()->sync($site_ids);
 
 			DB::commit();
+
+			// TODO: implement job for processing media based on content type
+			dispatch(new ProcessMedia($media));
+
 		} catch(Exception $e){
 			DB::rollBack();
 			throw $e;
 		}
-
-		// TODO: implement job for processing media based on content type
-		dispatch(new ProcessMedia($media));
 
 		return fractal($media, new MediaTransformer)->respond(201);
 	}

--- a/app/Policies/MediaPolicy.php
+++ b/app/Policies/MediaPolicy.php
@@ -6,26 +6,24 @@ use App\Policies\BasePolicy;
 use App\Models\User;
 use App\Models\Site;
 use App\Models\Media;
+use App\Models\Permission;
 
 class MediaPolicy extends BasePolicy
 {
     /**
      * Determine whether the user can index Media.
      *
-     * Accepts a string or an array (containing a Media class string and a Site
-     * instance) as the ACO.
-     *
      * @param User  $user
-     * @param string|array $aco
+     * @param Site|null Site
+     *
      * @return boolean
      */
-    public function index(User $user, $aco = null)
+    public function index(User $user, $site = null)
     {
-        if(is_array($aco) && isset($aco[1])){
-            if(is_a($aco[1], Site::class)){
-                return (new SitePolicy)->update($user, $aco[1]);
-            }
+        if(is_a($site, Site::class)) {
+            return (new SitePolicy)->view($user, $site);
         }
+
         return false;
     }
 
@@ -52,11 +50,12 @@ class MediaPolicy extends BasePolicy
      * @param Site|null Site
      * @return boolean
      */
-    public function create(User $user, $media, $site_or_pubgroup)
+    public function create(User $user, $media, $site)
     {
-        if( is_a($site_or_pubgroup, Site::class)){
-            return (new SitePolicy)->update($user, $site_or_pubgroup);
+        if(is_a($site, Site::class)) {
+            return $user->hasPermissionForSite(Permission::ADD_IMAGE, $site->id);
         }
+
         return false;
     }
 
@@ -80,6 +79,8 @@ class MediaPolicy extends BasePolicy
      *
      * Accepts a Media item or an array (a Media instance and a Site
      * instance) as the ACO.
+     *
+     * TODO: Remove this aco business.
      *
      * @param  User  $user
      * @param  Media|array  $aco


### PR DESCRIPTION
- If a user can view a site, then they can view media associated with that site.
- For now if a user has the "ADD_IMAGE" permission they can create media.

I'm pretty keen for us to decide on the correct permissions for media (not just images) and when we get the chance to write some better tests to check it's all working as intended.