### PR TITLE
Modify dynamic block behaviour to only add attributes to the data.

### DIFF
--- a/app/Models/Definitions/BaseDefinition.php
+++ b/app/Models/Definitions/BaseDefinition.php
@@ -339,6 +339,19 @@ abstract class BaseDefinition implements Arrayable, DefinitionContract, Jsonable
     }
 
 	/**
+	 * Get the names of all available dynamic attributes for this definition.
+	 * @return array
+	 */
+    public function getDynamicAttributeNames()
+	{
+		$names = [];
+		foreach($this->dynamicAttributes ?? [] as $attribute) {
+			$names[] = $attribute['name'];
+		}
+		return $names;
+	}
+
+	/**
 	 * Gets the name of the dynamic definition class.
 	 * Dynamic definition classes are the definition name (first character uppercased),
 	 * with any non-alpha-numeric characters removed (and the first following character uppercased)

--- a/app/Models/Definitions/Block.php
+++ b/app/Models/Definitions/Block.php
@@ -11,14 +11,14 @@ class Block extends BaseDefinition
 	];
 
 	/**
-	 * Optionally filter the data for this block.
+	 * Get any dynamically generated attributes for this block
 	 * @param array $block_data - Array of data with values for this block.
 	 * @param string $section_name - The name of the section this block is in.
 	 * @param string $region_name - The name of the region this block is in.
 	 * @param array $page_data - The page data (as structured to be sent as json) that this block is part of.
 	 * @return mixed Array of data.
 	 */
-	public function filterData($block_data, $section_name, $region_name, $page_data){ return $block_data; }
+	public function getDynamicAttributes($block_data, $section_name, $region_name, $page_data){ return []; }
 
 	/**
 	 * Provide dynamic routing.

--- a/dynamic-blocks.md
+++ b/dynamic-blocks.md
@@ -4,7 +4,7 @@
 
 Dynamic blocks do one or both of:
  * Dynamic routing (creating dynamic pages) for URLs below that of the page in which they are included.
- * Inject custom data into the block field data dynamically (via API calls, database access, calculations)
+ * Inject custom data into the block data dynamically (via API calls, database access, calculations)
  
 A dynamic block's definition.json MUST include the attribute "dynamic" with a value of 1 or true
 with a php block class extending ```App\Models\Definitions\Block```.
@@ -29,8 +29,11 @@ named
 
 ### Dynamic Content ###
 
-To modify the data returned in the 'fields' attribute for this block, the block class must implement the
-Block::filterData() method.
+Implement Block::getDynamicAttributes() to generate dynamic block data which will be included as
+part of the block data under a "dynamicAttributes" key when retrieving page json from the API.
+
+Any attributes returned by this method MUST also be defined in the "dynamicAttributes" property of
+the block's definition.json.
 
 ### Dynamic Routing ###
 


### PR DESCRIPTION
Any attributes that a dynamic block wishes to add must already be defined within the definition.json for that block.

Attempting to inject any other attributes will throw an exception.

Dynamic attributes are injected into a "dynamic" attribute in the page json for that block.

Currently these dynamic attributes are not available within the editor.

The renderer will need to be updated to allow access to these attributes within templates using just "dyanmic.{attribute-name}".