### PR TITLE
Fix/profile media uploads

### DIFF
--- a/app/Http/Controllers/Api/v1/MediaController.php
+++ b/app/Http/Controllers/Api/v1/MediaController.php
@@ -140,7 +140,9 @@ class MediaController extends ApiController
 		if($request->has('site_ids')){
 			$acos = $acos->merge(Site::whereIn('id', $request->get('site_ids'))->get());
 		}
-
+		if(count($acos) == 0) {
+			throw new \InvalidArgumentException('A site id is required.');
+		}
 		foreach($acos as $model){
 			$this->authorize($action, [ $media, $model ]);
 		}

--- a/resources/assets/js/components/MediaUpload.vue
+++ b/resources/assets/js/components/MediaUpload.vue
@@ -19,7 +19,7 @@
 			:accept="accept"
 			:multiple="multiple"
 			:on-success="onSuccess"
-			:site-id="Number(this.$route.params.site_id)"
+			:site-id="Number(this.$route.params.site_id || this.$route.params.siteId)"
 		/>
 	</div>
 </template>

--- a/resources/assets/js/routes.js
+++ b/resources/assets/js/routes.js
@@ -84,7 +84,7 @@ const routes = [
 		name: 'page'
 	},
 	{
-		path: '/site/:siteId/profile/:profileId',
+		path: '/site/:site_id/profile/:profileId',
 		components: {
 			default: ProfileEditor,
 			topbar: ProfileTopBar
@@ -96,7 +96,7 @@ const routes = [
 		}
 	},
 	{
-		path: '/site/:siteId/preview/profile/:profileId',
+		path: '/site/:site_id/preview/profile/:profileId',
 		component: ProfilePreview,
 		name: 'profile-preview',
 		props: true

--- a/resources/assets/js/routes.js
+++ b/resources/assets/js/routes.js
@@ -84,7 +84,7 @@ const routes = [
 		name: 'page'
 	},
 	{
-		path: '/site/:site_id/profile/:profileId',
+		path: '/site/:siteId/profile/:profileId',
 		components: {
 			default: ProfileEditor,
 			topbar: ProfileTopBar
@@ -96,7 +96,7 @@ const routes = [
 		}
 	},
 	{
-		path: '/site/:site_id/preview/profile/:profileId',
+		path: '/site/:siteId/preview/profile/:profileId',
 		component: ProfilePreview,
 		name: 'profile-preview',
 		props: true


### PR DESCRIPTION
Make uploading new media work on profiles.

It looks like the code expects to be able to use a site_id param from the route, however the router was configured to use siteId as the name of the param.

As site_id is used in all the other routes, and is what is expected in the code I have modified this.

I have also modified the media controller to throw an error if it doesn't get a site_id together when creating media.