### PR TITLE
Fix for real-time validation of blocks within a page

### DIFF
--- a/resources/assets/js/components/BlockForm.vue
+++ b/resources/assets/js/components/BlockForm.vue
@@ -1,13 +1,15 @@
 <script>
 /**
  * Custom form component for use with the block editor which reports its current validation
- * Sends a passValidation or failValidation event to its parent.
+ * Sends a block:setValidation event to the eventBus which can be optionally listened for.
+ * This is listened to by EditBlock for tracking block validation.
  *
  * Used within the editor sidebar to allow users to update blocks.
  *
  * @extends Element UI Form component
  */
 import { Form } from 'element-ui';
+import { eventBus } from 'plugins/eventbus';
 
 export default {
 	name: 'block-form',
@@ -28,27 +30,16 @@ export default {
 	},
 
 	watch: {
-		valid(isValid) {
-			if (isValid) {
-				this.$emit('passValidation');
-			}
-			else {
-				this.$emit('failValidation');
-			}
+		valid(status) {
+			eventBus.$emit('block:setValidation', status);
 		}
 	},
 
 	updated() {
 		// invoked when the form is loaded with a new block of data
-		this.validate((isValid) => {
-			if (isValid) {
-				this.$emit('passValidation');
-			}
-			else {
-				this.$emit('failValidation');
-			}
+		this.validate((status) => {
+			eventBus.$emit('block:failValidation', status);	
 		});
-
 	}
 };
 </script>

--- a/resources/assets/js/components/EditBlock.js
+++ b/resources/assets/js/components/EditBlock.js
@@ -1,5 +1,11 @@
+/**
+ * the block editing form for editing a single block within a page
+ * displayed in the sidebar
+ *
+ * listens to validation events from block-form and updates validation
+ * within the the global vuex state
+ */
 import { mapState, mapMutations, mapGetters } from 'vuex';
-
 import EditOptions from 'components/EditOptions';
 
 export default {
@@ -7,6 +13,11 @@ export default {
 	name: 'edit-block',
 
 	extends: EditOptions,
+
+	created() {
+		eventBus.$on('block:setValidation', this.setValidation);
+		eventBus.$on('block:setValidation', this.setValidation);
+	},
 
 	computed: {
 		...mapGetters([
@@ -53,15 +64,19 @@ export default {
 			'deleteBlockValidationIssue'
 		]),
 
+		/**
+		 * toggles the validation of this current block in the vuex state
+		 * @param {bool} status
+		 */
 		setValidation(status) {
-			if(status) {
-				this.deleteBlockValidationIssue(this.currentBlock.id);
-			}
-			else {
-				this.addBlockValidationIssue(this.currentBlock.id);
+			if (this.currentBlock) {
+				if (status) {
+					this.deleteBlockValidationIssue(this.currentBlock.id);
+				}
+				else {
+					this.addBlockValidationIssue(this.currentBlock.id);
+				}
 			}
 		}
-
 	}
-
 };

--- a/resources/assets/js/components/EditBlock.js
+++ b/resources/assets/js/components/EditBlock.js
@@ -16,7 +16,6 @@ export default {
 
 	created() {
 		eventBus.$on('block:setValidation', this.setValidation);
-		eventBus.$on('block:setValidation', this.setValidation);
 	},
 
 	computed: {


### PR DESCRIPTION
Restores the real-time validation for a page. (https://trello.com/c/EIHIFV85/427-regression-validation-error-realtime-notification-in-sidebar-no-longer-working)

Previous to the profile editor refactor the 'block-options' component listened to validation events emitted by its child block-form component and updated the list of validation issues in the vuex state. 

During the refactor the 'block-options' component was replaced by 'edit-block' and 'edit-profile' which extend from a common 'edit-options' component. However, 'edit-options' defines the template which removed the place where 'edit-block' could hook in listeners listening to events from its children. This broke the real-time display of validation errors within the page editor. 

This pull request updates 'block-form' to send those validation messages using the shared eventBus instead which is then listened to by 'edit-block'. 'edit-block' then updates the vuex state in the same method as 'block-options' did before.
