### PR TITLE
Fix/configurable urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 APP_HMR_URL=http://localhost:3000
 
+// URL patterns to use for viewing published pages and previewing draft pages
+APP_LIVE_URL_PATTERN=http://{domain}:8080{path}
+APP_PREVIEW_URL_PATTERN=http://astro.test:8080/draft/{domain}{path}
+
 KENT_API_URL=https://api.kent.ac.uk/api
 
 DEFINITIONS_PATH=

--- a/resources/assets/js/classes/helpers.js
+++ b/resources/assets/js/classes/helpers.js
@@ -145,8 +145,10 @@ export const pageHasBeenPublished = (page) => {
 
  * @returns {string} Full URL (with any trailing slash removed)
  */
-export const getDraftPreviewURL = (url) => {
-	return `${Config.get('base_url', '')}/draft/${url ? url.replace(/\/$/, '') : ''}`;
+export const getDraftPreviewURL = (domain, path) => {
+	let pattern = Config.get('draft_url_pattern') || '{domain}{path}';
+	return pattern.replace(/{domain}/ig, domain).replace(/{path}/ig, path);
+//	return `${Config.get('base_url', '')}/draft/${url ? url.replace(/\/$/, '') : ''}`;
 };
 
 /**
@@ -156,6 +158,9 @@ export const getDraftPreviewURL = (url) => {
 
  * @returns {string} Full URL (with any trailing slash removed)
  */
-export const getPublishedPreviewURL = (url) => {
-	return `${Config.get('base_url', '')}/published/${url ? url.replace(/\/$/, '') : ''}`;
+export const getPublishedPreviewURL = (domain, path) => {
+	let pattern = Config.get('published_url_pattern') || '{domain}{path}';
+	return pattern.replace(/{domain}/ig, domain).replace(/{path}/ig, path);
+
+//	return `${Config.get('base_url', '')}/published/${url ? url.replace(/\/$/, '') : ''}`;
 };

--- a/resources/assets/js/classes/helpers.js
+++ b/resources/assets/js/classes/helpers.js
@@ -140,9 +140,10 @@ export const pageHasBeenPublished = (page) => {
 
 /**
  * Get the URL at which the current page can be previewed in the editor.
-
- * @param {string} url - The page URL to mutate into a draft preview URL
-
+ *
+ * @param {string} domain - The domain name for the site.
+ * @param {string} path - The full path of the page to generate the URL for.
+ *
  * @returns {string} Full URL (with any trailing slash removed)
  */
 export const getDraftPreviewURL = (domain, path) => {
@@ -153,9 +154,10 @@ export const getDraftPreviewURL = (domain, path) => {
 
 /**
  * Get the URL at which the published version of the current page can be previewed in the editor.
-
- * @param {string} url - The page URL to mutate into a published preview URL.
-
+ *
+ * @param {string} domain - The domain name for the site.
+ * @param {string} path - The full path of the page to generate the URL for.
+ *
  * @returns {string} Full URL (with any trailing slash removed)
  */
 export const getPublishedPreviewURL = (domain, path) => {

--- a/resources/assets/js/components/PublishModal.vue
+++ b/resources/assets/js/components/PublishModal.vue
@@ -137,8 +137,9 @@ export default {
 			}
 		},
 
+		// the actual URL to display the rendered published page (can be different from the "real" site+page URL)
 		previewURL() {
-			return getPublishedPreviewURL(this.renderedURL);
+			return getPublishedPreviewURL(this.siteDomain, this.sitePath + (this.getSelectedPage.path === '/' ? '' : this.getSelectedPage.path));
 		},
 
 		// frontend URL - so the user can view the page's url

--- a/resources/assets/js/store/modules/page.js
+++ b/resources/assets/js/store/modules/page.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import Vue from 'vue';
-import { Definition } from 'classes/helpers';
+import { getPublishedPreviewURL, getDraftPreviewURL, Definition } from 'classes/helpers';
 import api from 'plugins/http/api';
 import { eventBus } from 'plugins/eventbus';
 import Config from 'classes/Config';
@@ -553,12 +553,7 @@ const getters = {
 	 * @returns {string} Full URL
 	 */
 	draftPreviewURL: (state, getters) => {
-		return (
-			Config.get('base_url', '') + '/draft/' +
-			getters.siteDomain +
-			getters.sitePath +
-			(getters.pagePath === '/' ? '' : getters.pagePath)
-		);
+		return getDraftPreviewURL(getters.siteDomain, getters.sitePath + (getters.pagePage === '/' ? '' : getters.pagePath));
 	},
 
 	/**
@@ -568,12 +563,7 @@ const getters = {
 	 * @returns {string} Full URL
 	 */
 	publishedPreviewURL: (state, getters) => {
-		return (
-			Config.get('base_url', '') + '/published/' +
-			getters.siteDomain +
-			getters.sitePath +
-			(getters.pagePath === '/' ? '' : getters.pagePath)
-		);
+		return getPublishedPreviewURL(getters.siteDomain, getters.sitePath + (getters.pagePage === '/' ? '' : getters.pagePath));
 	},
 
 	unsavedChangesExist: (state) => () => {

--- a/resources/views/inline.blade.php
+++ b/resources/views/inline.blade.php
@@ -27,7 +27,9 @@
 		'username' => $username,
 		'user'     => $user,
 		'api_token' => $api_token,
-		'debug' => config('app.debug')
+		'debug' => config('app.debug'),
+		'published_url_pattern' => env('APP_LIVE_URL_PATTERN'),
+		'draft_url_pattern' => env('APP_PREVIEW_URL_PATTERN')
 	]); ?>;
 	</script>
 


### PR DESCRIPTION
Added the following to the .env(.sample) to allow configuring of where the main website renderer and preview renderer are hosted.

// URL patterns to use for viewing published pages and previewing draft pages
APP_LIVE_URL_PATTERN=http://{domain}:8080{path}
APP_PREVIEW_URL_PATTERN=http://astro.test:8080/draft/{domain}{path}

It is the editor rather than the API that will use these, although the values are currently injected into the Editor's Config object
by the laravel bootstrapping code that creates the editor HTML page.

