### PR TITLE
adding machform url to config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,5 @@ HEAP_APP_ID=
 
 ENABLE_HOTJAR=false
 HOTJAR_ID=
+
+MACHFORM_URL=https://url-to-machform.com

--- a/resources/views/inline.blade.php
+++ b/resources/views/inline.blade.php
@@ -29,7 +29,8 @@
 		'api_token' => $api_token,
 		'debug' => config('app.debug'),
 		'published_url_pattern' => env('APP_LIVE_URL_PATTERN'),
-		'draft_url_pattern' => env('APP_PREVIEW_URL_PATTERN')
+		'draft_url_pattern' => env('APP_PREVIEW_URL_PATTERN'),
+		'machform_url' => env('MACHFORM_URL')
 	]); ?>;
 	</script>
 


### PR DESCRIPTION
keep the machform url in the .env rather than hardcode it