### PR TITLE
Feature/page dynamic block events

### DIFF
--- a/app/Events/PageEvent.php
+++ b/app/Events/PageEvent.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Page;
+
+/**
+ * A PageEvent is triggered whenever a page is about to change or has changed.
+ * The type of event can be determined from the $type attribute.
+ * The Page in its current state can be retrieved from the $page attribute. This will be the previous state of the
+ * page for ...ing events (e.g. creating) and the modified state of the page for '...ed' events (e.g. created).
+ * @package App\Events
+ */
+class PageEvent
+{
+	const PAGE_EVENT_WILDCARD = self::class;
+	const CREATING = 'astro.page.creating';
+	const CREATED = 'astro.page.created';
+	const UPDATING = 'astro.page.updating';
+	const UPDATED = 'astro.page.updated';
+	const DELETING = 'astro.page.deleting';
+	const DELETED = 'astro.page.deleted';
+	const PUBLISHING = 'astro.page.publishing';
+	const PUBLISHED = 'astro.page.published';
+	const UNPUBLISHING = 'astro.page.unpublishing';
+	const UNPUBLISHED = 'astro.page.unpublished';
+	const MOVING = 'astro.page.moving';
+	const MOVED = 'astro.page.moved';
+	const RENAMING = 'astro.page.renaming';
+	const RENAMED = 'astro.page.renamed';
+	const OPTIONS_UPDATING = 'astro.page.options_updating';
+	const OPTIONS_UPDATED = 'astro.page.options_updated';
+
+	/**
+	 * @var string The type of page change (create, update, etc)
+	 */
+	public $type;
+
+	/**
+	 * @var Page The Page data.
+	 */
+	public $page;
+
+	/**
+	 * @var array The changed data
+	 */
+	public $changes;
+
+	/**
+	 * PageEvent constructor.
+	 * @param string $type - The type of page
+	 * @param Page $page - The Page that has changed (in its current state)
+	 * @param array $changes - The data that has been changed (varies depending on event type)
+	 */
+	public function __construct($type, $page, $changes)
+	{
+		$this->type = $type;
+		$this->page = $page;
+		$this->changes = $changes;
+	}
+}

--- a/app/Events/PageEvent.php
+++ b/app/Events/PageEvent.php
@@ -9,6 +9,7 @@ use App\Models\Page;
  * The type of event can be determined from the $type attribute.
  * The Page in its current state can be retrieved from the $page attribute. This will be the previous state of the
  * page for ...ing events (e.g. creating) and the modified state of the page for '...ed' events (e.g. created).
+ * For Creating events, it will be null.
  * @package App\Events
  */
 class PageEvent
@@ -42,20 +43,20 @@ class PageEvent
 	public $page;
 
 	/**
-	 * @var array The changed data
+	 * @var array Additional, event-specific data
 	 */
-	public $changes;
+	public $data;
 
 	/**
 	 * PageEvent constructor.
 	 * @param string $type - The type of page
 	 * @param Page $page - The Page that has changed (in its current state)
-	 * @param array $changes - The data that has been changed (varies depending on event type)
+	 * @param array $data - Event-specific data
 	 */
-	public function __construct($type, $page, $changes)
+	public function __construct($type, $page, $data)
 	{
 		$this->type = $type;
 		$this->page = $page;
-		$this->changes = $changes;
+		$this->data = $data;
 	}
 }

--- a/app/Models/APICommands/AddPage.php
+++ b/app/Models/APICommands/AddPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Models\Revision;
 use DB;
 use App\Models\Page;
@@ -28,17 +29,15 @@ class AddPage implements APICommand
     {
         return DB::transaction(function() use($input, $user){
             $parent = Page::find($input['parent_id']);
-            $page = $this->addPage($parent,
+			$page = $this->addPage($parent,
                 $input['slug'],
                 $input['title'],
                 $user,
                 $input['layout']['name'],
-                $input['layout']['version']
+                $input['layout']['version'],
+				!empty($input['next_id']) ? $input['next_id'] : null
             );
-            if(!empty($input['next_id'])){
-                $page->makePreviousSiblingOf(Page::find($input['next_id']));
-            }
-            return $page;
+			return $page;
         });
     }
 

--- a/app/Models/APICommands/CreateSite.php
+++ b/app/Models/APICommands/CreateSite.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Models\Definitions\Layout;
 use App\Models\Definitions\SiteDefinition;
 use App\Models\Revision;
@@ -97,6 +98,14 @@ class CreateSite implements APICommand
      */
     public function createHomePage($site, $title, $layout, $user)
     {
+		event(new PageEvent(PageEvent::CREATING, null, [
+			'parent' => null,
+			'layout_name' => $layout['name'],
+			'layout_version' => $layout['version'],
+			'slug' => null,
+			'title' => $title,
+			'user' => $user
+		]));
         $page = Page::create([
             'site_id' => $site->id,
             'parent_id' => null,
@@ -118,7 +127,8 @@ class CreateSite implements APICommand
         ]);
         $page->setRevision($revision);
         $page->refresh();
-        return $page;
+		event(new PageEvent(PageEvent::CREATED, $page, null));
+		return $page;
     }
 
     /**

--- a/app/Models/APICommands/PublishPage.php
+++ b/app/Models/APICommands/PublishPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Exceptions\UnpublishedParentException;
 use App\Models\Contracts\APICommand;
 use App\Models\Page;
@@ -45,6 +46,7 @@ class PublishPage implements APICommand
 			// is there already a published page at this path?
 			$published_page = $page->publishedVersion();
 
+			event(new PageEvent(PageEvent::PUBLISHING, $page, null));
 			if (!$published_page) {
 				// does this page have a parent, and if so, has it been published?
 				$parent = $page->parent;
@@ -74,7 +76,7 @@ class PublishPage implements APICommand
 			}
 
 			$published_page->setRevision($page->revision);
-
+			event(new PageEvent(PageEvent::PUBLISHED, $published_page, null));
 			return $published_page;
 		});
 	}

--- a/app/Models/APICommands/UnpublishPage.php
+++ b/app/Models/APICommands/UnpublishPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Exceptions\UnpublishedPageException;
 use App\Models\Contracts\APICommand;
 use App\Models\Page;
@@ -25,9 +26,9 @@ class UnpublishPage implements APICommand
 	{
 		return DB::transaction(function () use ($input) {
 			$page = Page::find($input['id']);
-
+			event(new PageEvent(PageEvent::UNPUBLISHING, $page, null));
 			$page->publishedVersion()->delete();
-
+			event(new PageEvent(PageEvent::UNPUBLISHED, $page, null));
 			return $page;
 		});
 	}

--- a/app/Models/APICommands/UpdateContent.php
+++ b/app/Models/APICommands/UpdateContent.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Models\Contracts\APICommand;
 use App\Models\Definitions\Layout;
 use App\Models\Definitions\Region;
@@ -32,6 +33,8 @@ class UpdateContent implements APICommand
 		$result = DB::transaction(function () use ($input, $user) {
 			$page = Page::find($input['id']);
 
+			event(new PageEvent(PageEvent::UPDATING, $page, $input['blocks']));
+
 			// Update with new content.
 			$errors = $this->processBlocks($page, $input['blocks']);
 
@@ -50,6 +53,7 @@ class UpdateContent implements APICommand
 			]);
 			$page->setRevision($revision);
 			$page->fresh();
+			event(new PageEvent(PageEvent::UPDATED, $page, ['previous_revision' => $previous_revision]));
 			return $page;
 		});
 		return $result;

--- a/app/Models/APICommands/UpdatePage.php
+++ b/app/Models/APICommands/UpdatePage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Models\Contracts\APICommand;
 use App\Models\Revision;
 use DB;
@@ -53,6 +54,7 @@ class UpdatePage implements APICommand
 				}
 			}
 			if ($changed || (!empty($input['title']) && $input['title'] != $previous_revision->title)) {
+				event( new PageEvent(PageEvent::OPTIONS_UPDATING, $page, array_merge($options, ['title' => !empty($input['title']) ? $input['title'] : $previous_revision->title])));
 				$revision = Revision::create([
 					'revision_set_id' => $previous_revision->revision_set_id,
 					'title' => !empty($input['title']) ? $input['title'] : $previous_revision->title,
@@ -65,6 +67,7 @@ class UpdatePage implements APICommand
 					]);
 					$page->setRevision($revision);
 				}
+				event(new PageEvent(PageEvent::OPTIONS_UPDATED, $page, array_merge($previous_revision->options, ['title' => $previous_revision->title])));
 				return $page;
 			});
 			return $result;

--- a/app/Models/APICommands/UpdatePageSlug.php
+++ b/app/Models/APICommands/UpdatePageSlug.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\APICommands;
 
+use App\Events\PageEvent;
 use App\Models\Contracts\APICommand;
 use App\Models\Revision;
 use DB;
@@ -30,6 +31,8 @@ class UpdatePageSlug implements APICommand
 			if ($input['slug'] == $page->slug) {
 				return $page;
 			}
+			$old_slug = $page->slug;
+			event($page, ['new_slug' => $input['slug']]);
 			// update published version of page if there is one
 			// need to do this BEFORE updating the draft page, as we can only find the published version
 			// by looking for a page with the same path / slug
@@ -39,6 +42,7 @@ class UpdatePageSlug implements APICommand
 			}
 			$this->updateSlugAndPaths($page, $input['slug']);
 			$page->refresh();
+			event($page, ['old_slug' => $old_slug]);
 			return $page;
 		});
 		return $result;

--- a/app/Models/Definitions/Block.php
+++ b/app/Models/Definitions/Block.php
@@ -1,6 +1,9 @@
 <?php
 namespace App\Models\Definitions;
 
+use App\Events\PageEvent;
+use App\Models\Page;
+
 class Block extends BaseDefinition
 {
 
@@ -29,6 +32,17 @@ class Block extends BaseDefinition
 	 * @return bool
 	 */
 	public function route($path, &$block, $page) {return false;}
+
+	/**
+	 * Called whenever a page containing this block is changed, created, deleted, moved, etc
+	 * @param PageEvent $page_event - The object with information about this event.
+	 * @param array $block_data - The data defining this block
+	 * @param string $region_name - Name of the region containing this block.
+	 * @param int $section_index - Index within its region of the section containing this block.
+	 * @param array $section_def - Definition of the section containing this block ( ['name' => ..., 'blocks' => [...] ] )
+	 * @param int $block_index - The index of this block inside its section
+	 */
+	public function onPageStatusChange(PageEvent $page_event, array $block_data, $region_name, $section_index, $section_def, $block_index ) { }
 
 	/**
 	 * Are blocks of this type dynamic?

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -6,6 +6,7 @@ use App\Events\PageEvent;
 use DB;
 use Exception;
 use App\Models\Definitions\Layout as LayoutDefinition;
+use \App\Models\Definitions\Block as BlockDefinition;
 use Baum\Node as BaumNode;
 use App\Models\Definitions\Layout;
 use Illuminate\Support\Facades\Event;
@@ -80,11 +81,20 @@ class Page extends BaumNode
 	}
 
 	/**
-	 * @param string $event_name
-	 * @param PageEvent $data
+	 * Give dynamic blocks on a page the option to react to any page change events.
+	 * @param PageEvent $page_event
 	 */
-	protected static function handlePageEvent($event) {
-		// do something
+	protected static function handlePageEvent($page_event) {
+		if($page_event->page) {
+			foreach($page_event->page->revision->blocks as $region_name => $sections) {
+				foreach($sections as $section_index => $section_def) {
+					foreach($section_def['blocks'] as $block_index => $block_data) {
+						$definition = BlockDefinition::fromDefinitionFile(BlockDefinition::locateDefinition(BlockDefinition::idFromNameAndVersion($block_data['definition_name'], $block_data['definition_version'])));
+						$definition->onPageStatusChange($page_event, $block_data, $region_name, $section_index, $section_def, $block_index);
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use App\Events\PageEvent;
 use DB;
 use Exception;
 use App\Models\Definitions\Layout as LayoutDefinition;
 use Baum\Node as BaumNode;
 use App\Models\Definitions\Layout;
+use Illuminate\Support\Facades\Event;
+
 /**
  * A Page represents a path in a hierarchical site structure.
  * Each page has a current revision, and each "tree" of pages is scoped by its site_id and version (draft, published, etc).
@@ -70,10 +73,18 @@ class Page extends BaumNode
 	protected static function boot()
 	{
 		parent::boot();
-
+		Event::listen(PageEvent::PAGE_EVENT_WILDCARD, [static::class, 'handlePageEvent'] );
 		static::saving(function ($node) {
 			$node->path = $node->generatePath();
 		});
+	}
+
+	/**
+	 * @param string $event_name
+	 * @param PageEvent $data
+	 */
+	protected static function handlePageEvent($event) {
+		// do something
 	}
 
 	/**

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -114,4 +114,22 @@ class Site extends Model
 			->whereNull('parent_id')
 			->where('version', $version);
 	}
+
+	/**
+	 * Sets (and saves) the value of a site option
+	 * @param string $name - The option name
+	 * @param mixed $value - The option value.
+	 */
+	public function setOption($name, $value)
+	{
+		$options = $this->options;
+		if(null === $value) {
+			unset($options[$value]);
+		}
+		else {
+			$options[$name] = $value;
+		}
+		$this->options = $options;
+		$this->save();
+	}
 }


### PR DESCRIPTION
Adds page changing events to Astro using Laravel's standard events mechanism.

An App\Events\PageEvent event object is created and dispatched whenever a page changes.

Trigger a PageEvent whenever a page is modified and notify any dynamic blocks on that page.

The available events are defined as constants within the App\Events\PageEvent class.

This needs work in the future to include relevant / useful additional data for each event.