### PR TITLE
Pass the draft version of the page to all page events.

### DIFF
--- a/app/Models/APICommands/PublishPage.php
+++ b/app/Models/APICommands/PublishPage.php
@@ -74,9 +74,9 @@ class PublishPage implements APICommand
 					$published_page = Page::create($fields);
 				}
 			}
-
 			$published_page->setRevision($page->revision);
-			event(new PageEvent(PageEvent::PUBLISHED, $published_page, null));
+			$page->refresh();
+			event(new PageEvent(PageEvent::PUBLISHED, $page, null));
 			return $published_page;
 		});
 	}


### PR DESCRIPTION
For consistency of which page id is passed around events, due to the weird way that sam has implemented pages (draft or published).